### PR TITLE
Create Auth Gateway

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,11 @@ configurations {
 
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
+  testImplementation("org.wiremock:wiremock-standalone:3.3.1")
+  testImplementation("io.kotest:kotest-assertions-json-jvm:5.8.0")
+  testImplementation("io.kotest:kotest-runner-junit5-jvm:5.8.0")
+  testImplementation("io.kotest:kotest-assertions-core-jvm:5.8.0")
+  testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.3")
 }
 
 kotlin {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/gateways/HmppsAuthGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/gateways/HmppsAuthGateway.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestworker.gateways
+
+import org.apache.tomcat.util.json.JSONParser
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientRequestException
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import java.util.*
+
+@Component
+class HmppsAuthGateway(
+  @Value("\${services.hmpps-auth.base-url}") hmppsAuthUrl: String,
+  @Value("\${services.hmpps-auth.username}") var username: String,
+  @Value("\${services.hmpps-auth.password}") var password: String) {
+  private val webClient: WebClient = WebClient.builder().baseUrl(hmppsAuthUrl).build()
+
+
+  fun getClientToken(): String {
+    val encodedCredentials = Base64.getEncoder().encodeToString("$username:$password".toByteArray())
+    val basicAuthCredentials = "Basic $encodedCredentials"
+
+    return try {
+      val response = webClient
+        .post()
+        .uri("/auth/oauth/token?grant_type=client_credentials")
+        .header("Authorization", basicAuthCredentials)
+        .retrieve()
+        .bodyToMono(String::class.java)
+        .block()
+
+        JSONParser(response).parseObject()["access_token"].toString()
+      } catch (exception: WebClientRequestException) {
+        throw RuntimeException("Connection to ${exception.uri.authority} failed.")
+      } catch (exception: WebClientResponseException.ServiceUnavailable) {
+        throw RuntimeException("${exception.request?.uri?.authority} is unavailable.")
+      } catch (exception: WebClientResponseException.Unauthorized) {
+        throw RuntimeException("Invalid credentials used.")
+      }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/gateways/HmppsAuthGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/gateways/HmppsAuthGateway.kt
@@ -12,9 +12,9 @@ import java.util.*
 class HmppsAuthGateway(
   @Value("\${services.hmpps-auth.base-url}") hmppsAuthUrl: String,
   @Value("\${services.hmpps-auth.username}") var username: String,
-  @Value("\${services.hmpps-auth.password}") var password: String) {
+  @Value("\${services.hmpps-auth.password}") var password: String,
+) {
   private val webClient: WebClient = WebClient.builder().baseUrl(hmppsAuthUrl).build()
-
 
   fun getClientToken(): String {
     val encodedCredentials = Base64.getEncoder().encodeToString("$username:$password".toByteArray())
@@ -29,13 +29,13 @@ class HmppsAuthGateway(
         .bodyToMono(String::class.java)
         .block()
 
-        JSONParser(response).parseObject()["access_token"].toString()
-      } catch (exception: WebClientRequestException) {
-        throw RuntimeException("Connection to ${exception.uri.authority} failed.")
-      } catch (exception: WebClientResponseException.ServiceUnavailable) {
-        throw RuntimeException("${exception.request?.uri?.authority} is unavailable.")
-      } catch (exception: WebClientResponseException.Unauthorized) {
-        throw RuntimeException("Invalid credentials used.")
-      }
+      JSONParser(response).parseObject()["access_token"].toString()
+    } catch (exception: WebClientRequestException) {
+      throw RuntimeException("Connection to ${exception.uri.authority} failed.")
+    } catch (exception: WebClientResponseException.ServiceUnavailable) {
+      throw RuntimeException("${exception.request?.uri?.authority} is unavailable.")
+    } catch (exception: WebClientResponseException.Unauthorized) {
+      throw RuntimeException("Invalid credentials used.")
+    }
   }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,5 +1,5 @@
 services:
   hmpps-auth:
     base-url: https://sign-in-dev.hmpps.service.justice.gov.uk
-    username: ${CLIENT_ID}
-    password: ${CLIENT_SECRET}
+    username: ${SYSTEM_CLIENT_ID}
+    password: ${SYSTEM_CLIENT_SECRET}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,5 @@
+services:
+  hmpps-auth:
+    base-url: https://sign-in-dev.hmpps.service.justice.gov.uk
+    username: ${CLIENT_ID}
+    password: ${CLIENT_SECRET}

--- a/src/main/resources/application-local-docker.yml
+++ b/src/main/resources/application-local-docker.yml
@@ -1,0 +1,5 @@
+services:
+  hmpps-auth:
+    base-url: http://hmpps-auth:8080
+    username: hmpps-integration-api-client
+    password: clientsecret

--- a/src/main/resources/application-local-docker.yml
+++ b/src/main/resources/application-local-docker.yml
@@ -1,5 +1,5 @@
 services:
   hmpps-auth:
     base-url: http://hmpps-auth:8080
-    username: hmpps-integration-api-client
+    username: hmpps-integration-api-client # until we get a client seeded
     password: clientsecret

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,6 @@
+services:
+  hmpps-auth:
+    base-url: http://localhost:9090
+    username: hmpps-integration-api-client
+    password: clientsecret
+

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,6 +1,6 @@
 services:
   hmpps-auth:
     base-url: http://localhost:9090
-    username: hmpps-integration-api-client
+    username: hmpps-integration-api-client # until we get a client seeded
     password: clientsecret
 

--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -1,0 +1,5 @@
+services:
+  hmpps-auth:
+    base-url: https://sign-in-preprod.hmpps.service.justice.gov.uk
+    username: ${CLIENT_ID}
+    password: ${CLIENT_SECRET}

--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -1,5 +1,5 @@
 services:
   hmpps-auth:
     base-url: https://sign-in-preprod.hmpps.service.justice.gov.uk
-    username: ${CLIENT_ID}
-    password: ${CLIENT_SECRET}
+    username: ${SYSTEM_CLIENT_ID}
+    password: ${SYSTEM_CLIENT_SECRET}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,5 @@
+services:
+  hmpps-auth:
+    base-url: https://sign-in.hmpps.service.justice.gov.uk
+    username: ${CLIENT_ID}
+    password: ${CLIENT_SECRET}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,5 +1,5 @@
 services:
   hmpps-auth:
     base-url: https://sign-in.hmpps.service.justice.gov.uk
-    username: ${CLIENT_ID}
-    password: ${CLIENT_SECRET}
+    username: ${SYSTEM_CLIENT_ID}
+    password: ${SYSTEM_CLIENT_SECRET}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/gateways/HmppsAuthGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/gateways/HmppsAuthGatewayTest.kt
@@ -20,11 +20,18 @@ class HmppsAuthGatewayTest(hmppsAuthGateway: HmppsAuthGateway) :
     beforeEach {
       hmppsAuthMockServer.start()
 
-      hmppsAuthMockServer.stubGetOAuthToken("username", "password")
+      hmppsAuthMockServer.stubGetOAuthToken("mock-username", "mock-password")
     }
 
     afterTest {
       hmppsAuthMockServer.stop()
+    }
+
+    it("provides an auth token when called with valid client credentials") {
+
+      val token = hmppsAuthGateway.getClientToken()
+
+      token.shouldBe("mock-bearer-token")
     }
 
     it("throws an exception if connection is refused") {
@@ -37,4 +44,23 @@ class HmppsAuthGatewayTest(hmppsAuthGateway: HmppsAuthGateway) :
       exception.message.shouldBe("Connection to localhost:3000 failed.")
     }
 
-  })
+    it("throws an exception if auth service is unavailable") {
+      hmppsAuthMockServer.stubServiceUnavailableForGetOAuthToken()
+
+      val exception = shouldThrow<RuntimeException> {
+        hmppsAuthGateway.getClientToken()
+      }
+
+      exception.message.shouldBe("localhost:3000 is unavailable.")
+    }
+
+    it("throws an exception if credentials are invalid") {
+      hmppsAuthMockServer.stubUnauthorizedForGetOAAuthToken()
+
+      val exception = shouldThrow<RuntimeException> {
+        hmppsAuthGateway.getClientToken()
+      }
+
+      exception.message.shouldBe("Invalid credentials used.")
+    }
+  },)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/gateways/HmppsAuthGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/gateways/HmppsAuthGatewayTest.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestworker.gateways
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestworker.mockservers.HmppsAuthMockServer
+
+@ActiveProfiles("test")
+@ContextConfiguration(
+  initializers = [ConfigDataApplicationContextInitializer::class],
+  classes = [(HmppsAuthGateway::class)],
+)
+class HmppsAuthGatewayTest(hmppsAuthGateway: HmppsAuthGateway) :
+  DescribeSpec({
+    val hmppsAuthMockServer = HmppsAuthMockServer()
+
+    beforeEach {
+      hmppsAuthMockServer.start()
+
+      hmppsAuthMockServer.stubGetOAuthToken("username", "password")
+    }
+
+    afterTest {
+      hmppsAuthMockServer.stop()
+    }
+
+    it("throws an exception if connection is refused") {
+      hmppsAuthMockServer.stop()
+
+      val exception = shouldThrow<RuntimeException> {
+        hmppsAuthGateway.getClientToken()
+      }
+
+      exception.message.shouldBe("Connection to localhost:3000 failed.")
+    }
+
+  })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/mockservers/HmppsAuthMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/mockservers/HmppsAuthMockServer.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestworker.mockservers
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+
+class HmppsAuthMockServer : WireMockServer(WIREMOCK_PORT) {
+  companion object {
+    val TOKEN = "mock-bearer-token"
+    private const val WIREMOCK_PORT = 3000
+  }
+
+  private val authUrl = "/auth/oauth/token?grant_type=client_credentials"
+
+  fun stubGetOAuthToken(client: String, clientSecret: String) {
+    stubFor(
+      WireMock.post(authUrl)
+        .withBasicAuth(client, clientSecret)
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200)
+            .withBody(
+              """
+                { 
+                  "access_token": "$TOKEN"
+                }
+              """.trimIndent(),
+            ),
+        ),
+    )
+  }
+
+  fun stubServiceUnavailableForGetOAuthToken() {
+    stubFor(
+      WireMock.post(authUrl)
+        .willReturn(
+          WireMock.serviceUnavailable(),
+        ),
+    )
+  }
+
+  fun stubUnauthorizedForGetOAAuthToken() {
+    stubFor(
+      WireMock.post(authUrl)
+        .willReturn(
+          WireMock.unauthorized(),
+        ),
+    )
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,3 +4,9 @@ server:
 management.endpoint:
   health.cache.time-to-live: 0
   info.cache.time-to-live: 0
+
+services:
+  hmpps-auth:
+    base-url: http://localhost:3000
+    username: mock-username
+    password: mock-password


### PR DESCRIPTION
## Context

Ticket [SR-92](https://dsdmoj.atlassian.net/browse/SR-92) deals with the retrieval of data from relevant upstream services. To retrieve data from these HMPPS systems a person or system must first authenticate through HMPPS Auth, demonstrating that they have the appropriate roles attached to their client to be able to access the requested data. 

## Changes proposed in this pull request

* Adds into the system the gateway for interaction with the HMPPS Auth service. This enables the service to retrieve a client token from the auth service for use when sending requests to upstream HMPPS services.


## Next steps

* Build a generic service gateway to handle data requests to upstream systems.
* Build a service to handle the logic of requests to upstream systems and collation of data.

[SR-92]: https://dsdmoj.atlassian.net/browse/SR-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ