### PR TITLE
Poller mods

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ configurations {
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.3")
   testImplementation("org.wiremock:wiremock-standalone:3.3.1")
   testImplementation("io.kotest:kotest-assertions-json-jvm:5.8.0")
   testImplementation("io.kotest:kotest-runner-junit5-jvm:5.8.0")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/controllers/SubjectAccessRequestWorkerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/controllers/SubjectAccessRequestWorkerController.kt
@@ -13,7 +13,7 @@ class SubjectAccessRequestWorkerController(@Autowired val subjectAccessRequestSe
   @EventListener(
     ApplicationReadyEvent::class,
   )
-  fun startPolling() {
+  suspend fun startPolling() {
     subjectAccessRequestService.startPolling()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestworker.services
 
+import kotlinx.coroutines.delay
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatusCode
@@ -12,12 +13,16 @@ import java.time.Duration
 @Service
 class SubjectAccessRequestWorkerService(
   @Autowired val sarGateway: SubjectAccessRequestGateway,
-  @Value("\${services.poller.run-once}")
-  private val runOnce: String? = "false",
   @Value("\${services.sar-api.base-url}")
   private val sarUrl: String,
 ) {
-  fun startPolling() {
+  suspend fun startPolling() {
+    while (true) {
+      doPoll()
+    }
+  }
+
+  suspend fun doPoll() {
     val webClient = sarGateway.getClient(sarUrl)
     val token = sarGateway.getClientTokenFromHmppsAuth()
     val chosenSAR = this.pollForNewSubjectAccessRequests(webClient, token)
@@ -26,19 +31,13 @@ class SubjectAccessRequestWorkerService(
       doReport(chosenSAR)
       sarGateway.complete(webClient, chosenSAR, token)
     }
-
-    if (runOnce == "true") {
-      return
-    } else {
-      startPolling()
-    }
   }
 
-  fun pollForNewSubjectAccessRequests(client: WebClient, token: String): SubjectAccessRequest {
+  suspend fun pollForNewSubjectAccessRequests(client: WebClient, token: String): SubjectAccessRequest {
     var response: Array<SubjectAccessRequest>? = emptyArray()
 
     while (response.isNullOrEmpty()) {
-      Thread.sleep(Duration.ofSeconds(10))
+      delay(10)
       response = sarGateway.getUnclaimed(client, token)
     }
     return response.first()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestworker.gateways.SubjectAccessRequestGateway
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestworker.models.SubjectAccessRequest
-import java.time.Duration
 
 @Service
 class SubjectAccessRequestWorkerService(

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,8 +4,5 @@ services:
     username: ${SYSTEM_CLIENT_ID}
     password: ${SYSTEM_CLIENT_SECRET}
 
-  poller:
-    run-once: true
-
   sar-api:
     base-url: https://subject-access-request-api-dev.hmpps.service.justice.gov.uk

--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -4,8 +4,5 @@ services:
     username: ${SYSTEM_CLIENT_ID}
     password: ${SYSTEM_CLIENT_SECRET}
 
-  poller:
-    run-once: true
-
   sar-api:
     base-url: https://subject-access-request-api-preprod.hmpps.service.justice.gov.uk

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,8 +4,5 @@ services:
     username: ${SYSTEM_CLIENT_ID}
     password: ${SYSTEM_CLIENT_SECRET}
 
-  poller:
-    run-once: true
-
   sar-api:
     base-url: https://subject-access-request-api.hmpps.service.justice.gov.uk

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,7 +47,3 @@ management:
     info:
       cache:
         time-to-live: 2000ms
-
-services:
-  poller:
-    run-once: true

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,8 +11,5 @@ services:
     username: mock-username
     password: mock-password
 
-  poller:
-    run-once: true
-
   sar-api:
     base-url: http://localhost:8080


### PR DESCRIPTION
- Make the time delay non-blocking by using Kotlin coroutines delay() rather than Thread.sleep() which is blocking
- Move the core functionality in startPolling into doPoll
- Remove use of runOnce - no longer required as a result of the separation mentioned above
- Use runTest from Kotlin coroutines test suite to handle suspend functions