### PR TITLE
Add file prefix for FileSystemResource.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/gateways/DocumentStorageGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/gateways/DocumentStorageGateway.kt
@@ -31,7 +31,7 @@ class DocumentStorageGateway(
     val multipartBodyBuilder = MultipartBodyBuilder()
     log.info(
       "BUILDER: " + multipartBodyBuilder.apply {
-        part("file", FileSystemResource(filePath))
+        part("file", FileSystemResource("file:$filePath"))
         part("metadata", 1)
       }.build().toString(),
     )


### PR DESCRIPTION
To account for this:
https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/io/FileSystemResourceLoader.html
"NOTE: Plain paths will always be interpreted as relative to the current VM working directory, even if they start with a slash. (This is consistent with the semantics in a Servlet container.) Use an explicit "file:" prefix to enforce an absolute file path."