### PR TITLE
Add margins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,5 @@ It then performs a search and replace and directory renames so the project is re
 To allow easy identification of an application, the product Id of the overall product should be set in `values.yaml`. 
 The Service Catalogue contains a list of these IDs and is currently in development here https://developer-portal.hmpps.service.justice.gov.uk/products
 
-## Devloper notes
+## Developer notes
 PDF generation is done using iText. The most useful/in-depth documentation can be found here: https://itextpdf.com/sites/default/files/attachments/PR%20-%20iText%20in%20Action%20-%20Second%20edition%20e-book_0.pdf

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
@@ -27,6 +27,7 @@ class GeneratePdfService {
     val writer = getPdfWriter(document, pdfStream)
     val event = getCustomHeader(nID, sarID)
     setEvent(writer, event)
+    document.setMargins(50F, 50F, 100F, 50F)
     document.open()
     log.info("Started writing to PDF")
     addData(document, content)


### PR DESCRIPTION
The header doesn't show at the moment. This may be because it references relative to the margins and they haven't been set yet. The defaults may take the header off the page