### PR TITLE
Fix bug from passing both Nomis ID and nDelius ID

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/gateways/GenericHmppsApiGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/gateways/GenericHmppsApiGateway.kt
@@ -20,12 +20,19 @@ class GenericHmppsApiGateway(
     val response = webClient
       .get()
       .uri { builder ->
-        builder.path("/subject-access-request")
-          .queryParam("prn", prn)
-          .queryParam("crn", crn)
-          .queryParam("fromDate", dateFrom)
-          .queryParam("toDate", dateTo)
-          .build()
+        if (prn == null) {
+          builder.path("/subject-access-request")
+            .queryParam("crn", crn)
+            .queryParam("fromDate", dateFrom)
+            .queryParam("toDate", dateTo)
+            .build()
+        } else {
+          builder.path("/subject-access-request")
+            .queryParam("prn", prn)
+            .queryParam("fromDate", dateFrom)
+            .queryParam("toDate", dateTo)
+            .build()
+        }
       }
       .header("Authorization", "Bearer $clientToken")
       .retrieve()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/gateways/GenericHmppsApiGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/gateways/GenericHmppsApiGateway.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestworker.config.trackEvent
 import java.time.LocalDate
+import java.util.Optional
 
 @Component
 class GenericHmppsApiGateway(
@@ -20,19 +21,12 @@ class GenericHmppsApiGateway(
     val response = webClient
       .get()
       .uri { builder ->
-        if (prn == null) {
-          builder.path("/subject-access-request")
-            .queryParam("crn", crn)
-            .queryParam("fromDate", dateFrom)
-            .queryParam("toDate", dateTo)
-            .build()
-        } else {
-          builder.path("/subject-access-request")
-            .queryParam("prn", prn)
-            .queryParam("fromDate", dateFrom)
-            .queryParam("toDate", dateTo)
-            .build()
-        }
+        builder.path("/subject-access-request")
+          .queryParamIfPresent("prn", Optional.ofNullable(prn))
+          .queryParamIfPresent("crn", Optional.ofNullable(crn))
+          .queryParam("fromDate", dateFrom)
+          .queryParam("toDate", dateTo)
+          .build()
       }
       .header("Authorization", "Bearer $clientToken")
       .retrieve()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/gateways/GenericHmppsApiGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/gateways/GenericHmppsApiGatewayTest.kt
@@ -40,7 +40,6 @@ class GenericHmppsApiGatewayTest(
     }
 
     describe("getSarData") {
-
       it("authenticates using HMPPS Auth with credentials") {
         genericHmppsApiGateway.getSarData(
           "http://localhost:4000",
@@ -65,7 +64,6 @@ class GenericHmppsApiGatewayTest(
       }
 
       it("returns an error if unable to get a response") {
-
         val exception = shouldThrow<RuntimeException> {
           genericHmppsApiGateway.getSarData(
             "http://localhost:4000",
@@ -73,7 +71,7 @@ class GenericHmppsApiGatewayTest(
           )
         }
 
-        exception.message.shouldBe("404 Not Found from GET http://localhost:4000/subject-access-request?prn=personNotFoundInSystem&crn&fromDate&toDate")
+        exception.message.shouldBe("404 Not Found from GET http://localhost:4000/subject-access-request?prn=personNotFoundInSystem&fromDate&toDate")
       }
     }
   },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/mockservers/ComplexityOfNeedMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/mockservers/ComplexityOfNeedMockServer.kt
@@ -10,7 +10,7 @@ class ComplexityOfNeedMockServer : WireMockServer(WIREMOCK_PORT) {
     private const val WIREMOCK_PORT = 4000
   }
 
-  private val sarEndpoint = "/subject-access-request?prn=validPrn&crn&fromDate&toDate"
+  private val sarEndpoint = "/subject-access-request?prn=validPrn&fromDate&toDate"
 
   fun stubGetSubjectAccessRequestData() {
     stubFor(


### PR DESCRIPTION
## Context
Some upstream HMPPS APIs error when they receive query parameters for both PRN (Nomis ID) and CRN (nDelius ID). This prevents the SAR worker from completing the task of generating a report.

## Changes proposed in this PR
Upstream HMPPS APIs will now receive only PRN **OR** CRN, depending on which ID was provided by the user when requesting the report.