### PR TITLE
Add page breaks between service sections

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
@@ -134,6 +134,7 @@ class GeneratePdfService {
     }
     log.info("Adding data to PDF")
     document.add(para)
+    document.add(AreaBreak(AreaBreakType.NEXT_PAGE))
     log.info("Added data to PDF")
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
@@ -193,28 +193,6 @@ class GeneratePdfService {
     document.add(Paragraph("\nOFFICIAL-SENSITIVE").setTextAlignment(TextAlignment.CENTER).setFontSize(16f))
   }
 
-  fun addInternalContentsPage(
-    pdfDocument: PdfDocument,
-    document: Document,
-    serviceMap: MutableMap<String, String>,
-  ) {
-    val font = PdfFontFactory.createFont(StandardFonts.HELVETICA)
-    val contentsPageText = Paragraph().setFont(font).setFontSize(16f).setTextAlignment(TextAlignment.CENTER)
-    document.add(AreaBreak(AreaBreakType.NEXT_PAGE))
-    contentsPageText.add(Text("\n\n\n"))
-    contentsPageText.add(Text("CONTENTS\n"))
-    document.add(contentsPageText)
-
-    val serviceList = Paragraph()
-    serviceMap.keys.toList().forEach {
-      serviceList.add("\u2022 $it\n").setTextAlignment(TextAlignment.CENTER).setFontSize(14f)
-    }
-    document.add(serviceList)
-
-    document.add(Paragraph("\n\nINTERNAL ONLY").setTextAlignment(TextAlignment.CENTER).setFontSize(16f))
-    document.add(Paragraph("\nOFFICIAL-SENSITIVE").setTextAlignment(TextAlignment.CENTER).setFontSize(16f))
-  }
-
   fun getSubjectIdLine(nomisId: String?, ndeliusCaseReferenceId: String?): String {
     var subjectIdLine = ""
     if (nomisId != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
@@ -101,11 +101,13 @@ class GeneratePdfService {
   }
 
   fun addData(pdfDocument: PdfDocument, document: Document, content: Map<String, Any>) {
-    document.add(AreaBreak(AreaBreakType.NEXT_PAGE))
-    val font = PdfFontFactory.createFont(StandardFonts.HELVETICA)
-    val para = Paragraph().setFixedLeading(DATA_LINE_SPACING)
-    val boldFont = PdfFontFactory.createFont(StandardFonts.HELVETICA_BOLD)
+
+
     content.forEach { entry ->
+      document.add(AreaBreak(AreaBreakType.NEXT_PAGE))
+      val font = PdfFontFactory.createFont(StandardFonts.HELVETICA)
+      val para = Paragraph().setFixedLeading(DATA_LINE_SPACING)
+      val boldFont = PdfFontFactory.createFont(StandardFonts.HELVETICA_BOLD)
       log.info("Compiling data from " + entry.key)
       para.add(
         Text("${HeadingHelper.format(entry.key)}\n")
@@ -129,12 +131,9 @@ class GeneratePdfService {
       para.add(text)
         .setFont(font)
         .setFontSize(DATA_FONT_SIZE)
-      para.add("\n")
       log.info("Compiling data from " + entry.key)
+      document.add(para)
     }
-    log.info("Adding data to PDF")
-    document.add(para)
-    document.add(AreaBreak(AreaBreakType.NEXT_PAGE))
     log.info("Added data to PDF")
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
@@ -101,8 +101,6 @@ class GeneratePdfService {
   }
 
   fun addData(pdfDocument: PdfDocument, document: Document, content: Map<String, Any>) {
-
-
     content.forEach { entry ->
       document.add(AreaBreak(AreaBreakType.NEXT_PAGE))
       val font = PdfFontFactory.createFont(StandardFonts.HELVETICA)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfServiceTest.kt
@@ -87,7 +87,9 @@ class GeneratePdfServiceTest(
         val page = reader.getPage(2)
         val text = PdfTextExtractor.getTextFromPage(page)
         Assertions.assertThat(text).contains("Fake service name 1")
-        Assertions.assertThat(text).contains("Fake service name 2")
+        val page2 = reader.getPage(3)
+        val text2 = PdfTextExtractor.getTextFromPage(page2)
+        Assertions.assertThat(text2).contains("Fake service name 2")
       }
 
       describe("cover pages") {
@@ -236,7 +238,7 @@ class GeneratePdfServiceTest(
         mockPdfDocument.addEventHandler(PdfDocumentEvent.END_PAGE, CustomHeaderEventHandler(mockPdfDocument, mockDocument, "testHeader", "123456"))
         generatePdfService.addData(mockPdfDocument, mockDocument, testResponseObject)
         generatePdfService.addRearPage(mockPdfDocument, mockDocument, mockPdfDocument.numberOfPages)
-        Assertions.assertThat(mockPdfDocument.numberOfPages).isEqualTo(5)
+        Assertions.assertThat(mockPdfDocument.numberOfPages).isEqualTo(4)
         mockDocument.close()
         val reader = PdfDocument(PdfReader("dummy.pdf"))
         val page = reader.getPage(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfServiceTest.kt
@@ -236,7 +236,7 @@ class GeneratePdfServiceTest(
         mockPdfDocument.addEventHandler(PdfDocumentEvent.END_PAGE, CustomHeaderEventHandler(mockPdfDocument, mockDocument, "testHeader", "123456"))
         generatePdfService.addData(mockPdfDocument, mockDocument, testResponseObject)
         generatePdfService.addRearPage(mockPdfDocument, mockDocument, mockPdfDocument.numberOfPages)
-        Assertions.assertThat(mockPdfDocument.numberOfPages).isEqualTo(4)
+        Assertions.assertThat(mockPdfDocument.numberOfPages).isEqualTo(5)
         mockDocument.close()
         val reader = PdfDocument(PdfReader("dummy.pdf"))
         val page = reader.getPage(1)


### PR DESCRIPTION
This PR adds a page break between sections of data from the services. This is so that vetting team members can easily remove sections of the report.

<img width="404" alt="image" src="https://github.com/ministryofjustice/hmpps-subject-access-request-worker/assets/67278233/e8354d16-3f82-42db-b1d3-14309de71706">
