### PR TITLE
Don't write new files, just read from the streams when merging PDFs.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
@@ -31,7 +31,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
-
 const val DATA_HEADER_FONT_SIZE = 16f
 const val DATA_FONT_SIZE = 12f
 const val DATA_LINE_SPACING = 16f

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
@@ -25,10 +25,12 @@ import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestworker.models.Custo
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestworker.utils.DateConversionHelper
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestworker.utils.HeadingHelper
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestworker.utils.ProcessDataHelper
+import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
+
 
 const val DATA_HEADER_FONT_SIZE = 16f
 const val DATA_FONT_SIZE = 12f
@@ -51,8 +53,9 @@ class GeneratePdfService {
     pdfStream: ByteArrayOutputStream = createPdfStream(),
   ): ByteArrayOutputStream {
     log.info("Saving report..")
-    val writer = getPdfWriter(pdfStream)
-    val pdfDocument = PdfDocument(PdfWriter("main.pdf"))
+    val fullDocumentWriter = getPdfWriter(pdfStream)
+    val mainPdfStream = createPdfStream()
+    val pdfDocument = PdfDocument(PdfWriter(mainPdfStream))
     val document = Document(pdfDocument)
     log.info("Started writing to PDF")
     addExternalCoverPage(
@@ -83,7 +86,8 @@ class GeneratePdfService {
     log.info("Finished writing report")
     document.close()
 
-    val coverPage = PdfDocument(PdfWriter("cover.pdf"))
+    val coverPdfStream = createPdfStream()
+    val coverPage = PdfDocument(PdfWriter(coverPdfStream))
     val coverPageDocument = Document(coverPage)
     addInternalCoverPage(
       coverPageDocument,
@@ -97,10 +101,10 @@ class GeneratePdfService {
     )
     coverPageDocument.close()
 
-    val fullDocument = PdfDocument(writer)
+    val fullDocument = PdfDocument(fullDocumentWriter)
     val merger = PdfMerger(fullDocument)
-    val cover = PdfDocument(PdfReader("cover.pdf"))
-    val mainContent = PdfDocument(PdfReader("main.pdf"))
+    val cover = PdfDocument(PdfReader(ByteArrayInputStream(coverPdfStream.toByteArray())))
+    val mainContent = PdfDocument(PdfReader(ByteArrayInputStream(mainPdfStream.toByteArray())))
     merger.merge(cover, 1, 1)
     merger.merge(mainContent, 1, mainContent.numberOfPages)
     cover.close()


### PR DESCRIPTION
This approach removes the need to write and read from completed files.