### PR TITLE
Add footer to each page.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/models/CustomHeaderEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/models/CustomHeaderEventHandler.kt
@@ -28,7 +28,7 @@ class CustomHeaderEventHandler(private val pdfDoc: PdfDocument, val document: Do
     val pageSize = docEvent.page.pageSize
     val leftCoord = pageSize.left + document.leftMargin
     val rightCoord = pageSize.right - document.rightMargin
-    val midCoord = (leftCoord + rightCoord)/2
+    val midCoord = (leftCoord + rightCoord) / 2
     val headerY: Float = pageSize.top - document.topMargin + 10
     val footerY: Float = pageSize.bottom + 20
     val canvas = Canvas(docEvent.page, pageSize)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/models/CustomHeaderEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/models/CustomHeaderEventHandler.kt
@@ -15,29 +15,43 @@ class CustomHeaderEventHandler(private val pdfDoc: PdfDocument, val document: Do
 
   override fun handleEvent(currentEvent: Event) {
     val docEvent = currentEvent as PdfDocumentEvent
+    val leftHeaderText: String
+    val rightHeaderText: String
     if (pdfDoc.getPageNumber(docEvent.page) <= 2) {
-      return
+      leftHeaderText = ""
+      rightHeaderText = ""
+    } else {
+      leftHeaderText = nID
+      rightHeaderText = "CASE REFERENCE: $sarID"
     }
     val font: PdfFont = PdfFontFactory.createFont(StandardFonts.HELVETICA)
     val pageSize = docEvent.page.pageSize
     val leftCoord = pageSize.left + document.leftMargin
     val rightCoord = pageSize.right - document.rightMargin
+    val midCoord = (leftCoord + rightCoord)/2
     val headerY: Float = pageSize.top - document.topMargin + 10
+    val footerY: Float = pageSize.bottom + document.bottomMargin + 10
     val canvas = Canvas(docEvent.page, pageSize)
     canvas
       .setFont(font)
       .setFontSize(10f)
       .showTextAligned(
-        nID,
+        leftHeaderText,
         leftCoord,
         headerY,
         TextAlignment.LEFT,
       )
       .showTextAligned(
-        "CASE REFERENCE: $sarID",
+        rightHeaderText,
         rightCoord,
         headerY,
         TextAlignment.RIGHT,
+      )
+      .showTextAligned(
+        "Official Sensitive",
+        midCoord,
+        footerY,
+        TextAlignment.CENTER,
       )
       .close()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/models/CustomHeaderEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/models/CustomHeaderEventHandler.kt
@@ -30,7 +30,7 @@ class CustomHeaderEventHandler(private val pdfDoc: PdfDocument, val document: Do
     val rightCoord = pageSize.right - document.rightMargin
     val midCoord = (leftCoord + rightCoord)/2
     val headerY: Float = pageSize.top - document.topMargin + 10
-    val footerY: Float = pageSize.bottom + document.bottomMargin + 10
+    val footerY: Float = pageSize.bottom + 20
     val canvas = Canvas(docEvent.page, pageSize)
     canvas
       .setFont(font)


### PR DESCRIPTION
Add a footer to each page of the report.
It doesn't include the internal cover page.
The text may need to be changed in future if the wording isn't correct, or if we need to use a different footer for each service.

<img width="1068" alt="image" src="https://github.com/ministryofjustice/hmpps-subject-access-request-worker/assets/67278233/aff903fb-d92a-4eca-9b1e-4f78cbb4f80a">

<img width="1068" alt="image" src="https://github.com/ministryofjustice/hmpps-subject-access-request-worker/assets/67278233/4429f0eb-af03-44c7-9485-9de21b77819b">


