### PR TITLE
Reorder pages so internal only pages are adjacent.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
@@ -212,6 +212,7 @@ class GeneratePdfService {
     dateTo: LocalDate?,
     serviceMap: MutableMap<String, String>,
   ) {
+    document.add(AreaBreak(AreaBreakType.NEXT_PAGE))
     val font = PdfFontFactory.createFont(StandardFonts.HELVETICA)
     val coverpageText = Paragraph().setFont(font).setFontSize(16f).setTextAlignment(TextAlignment.CENTER)
     coverpageText.add(Text("\u00a0\n").setFontSize(180f))
@@ -228,7 +229,6 @@ class GeneratePdfService {
   ) {
     val font = PdfFontFactory.createFont(StandardFonts.HELVETICA)
     val contentsPageText = Paragraph().setFont(font).setFontSize(16f).setTextAlignment(TextAlignment.CENTER)
-    document.add(AreaBreak(AreaBreakType.NEXT_PAGE))
     contentsPageText.add(Text("\n\n\n"))
     contentsPageText.add(Text("CONTENTS\n"))
     document.add(contentsPageText)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
@@ -57,6 +57,7 @@ class GeneratePdfService {
     val pdfDocument = PdfDocument(PdfWriter(mainPdfStream))
     val document = Document(pdfDocument)
     log.info("Started writing to PDF")
+    addInternalContentsPage(pdfDocument, document, serviceMap)
     addExternalCoverPage(
       pdfDocument,
       document,
@@ -67,7 +68,6 @@ class GeneratePdfService {
       dateTo,
       serviceMap,
     )
-    addInternalContentsPage(pdfDocument, document, serviceMap)
     pdfDocument.addEventHandler(
       PdfDocumentEvent.END_PAGE,
       CustomHeaderEventHandler(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfServiceTest.kt
@@ -116,7 +116,7 @@ class GeneratePdfServiceTest(
           generatePdfService.addInternalContentsPage(mockPdfDocument, mockDocument, mutableMapOf("mockService" to "mockServiceUrl"))
           mockDocument.close()
           val reader = PdfDocument(PdfReader("dummy.pdf"))
-          val page = reader.getPage(1mit )
+          val page = reader.getPage(1)
           val text = PdfTextExtractor.getTextFromPage(page)
           Assertions.assertThat(text).contains("CONTENTS")
           Assertions.assertThat(text).contains("OFFICIAL-SENSITIVE")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfServiceTest.kt
@@ -116,7 +116,7 @@ class GeneratePdfServiceTest(
           generatePdfService.addInternalContentsPage(mockPdfDocument, mockDocument, mutableMapOf("mockService" to "mockServiceUrl"))
           mockDocument.close()
           val reader = PdfDocument(PdfReader("dummy.pdf"))
-          val page = reader.getPage(2)
+          val page = reader.getPage(1mit )
           val text = PdfTextExtractor.getTextFromPage(page)
           Assertions.assertThat(text).contains("CONTENTS")
           Assertions.assertThat(text).contains("OFFICIAL-SENSITIVE")


### PR DESCRIPTION
I think this might make more sense from a Branston-team perspective.

<img width="1068" alt="image" src="https://github.com/ministryofjustice/hmpps-subject-access-request-worker/assets/67278233/9cbec57f-6529-4908-82eb-a850f1f81d0c">

<img width="1068" alt="image" src="https://github.com/ministryofjustice/hmpps-subject-access-request-worker/assets/67278233/b4e51722-0055-48c9-800c-d3eb26d23f95">


