### PR TITLE
Remove duplicated security classification

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
@@ -241,7 +241,6 @@ class GeneratePdfService {
     document.add(serviceList)
 
     document.add(Paragraph("\n\nINTERNAL ONLY").setTextAlignment(TextAlignment.CENTER).setFontSize(16f))
-    document.add(Paragraph("\nOFFICIAL-SENSITIVE").setTextAlignment(TextAlignment.CENTER).setFontSize(16f))
   }
 
   fun getSubjectIdLine(nomisId: String?, ndeliusCaseReferenceId: String?): String {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
@@ -128,7 +128,7 @@ class GeneratePdfService {
     val endPageText = Paragraph().setFont(font).setFontSize(16f).setTextAlignment(TextAlignment.CENTER)
     document.add(Paragraph("\u00a0").setFontSize(300f))
     endPageText.add(Text("End of Subject Access Request Report\n\n"))
-    endPageText.add(Text("Total pages: ${numPages + 1}"))
+    endPageText.add(Text("Total pages: ${numPages + 2}"))
     document.add(endPageText)
   }
 
@@ -197,7 +197,7 @@ class GeneratePdfService {
       ).setTextAlignment(TextAlignment.CENTER),
     )
     document.add(Paragraph("${getServiceListLine(serviceMap)}\n").setTextAlignment(TextAlignment.CENTER))
-    document.add(Paragraph("\nTOTAL PAGES ${numPages + 1}").setTextAlignment(TextAlignment.CENTER).setFontSize(16f))
+    document.add(Paragraph("\nTotal Pages: ${numPages + 2}").setTextAlignment(TextAlignment.CENTER).setFontSize(16f))
     document.add(Paragraph("\nINTERNAL ONLY").setTextAlignment(TextAlignment.CENTER).setFontSize(16f))
     document.add(Paragraph("\nOFFICIAL-SENSITIVE").setTextAlignment(TextAlignment.CENTER).setFontSize(16f))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfServiceTest.kt
@@ -155,7 +155,6 @@ class GeneratePdfServiceTest(
           val page = reader.getPage(1)
           val text = PdfTextExtractor.getTextFromPage(page)
           Assertions.assertThat(text).contains("CONTENTS")
-          Assertions.assertThat(text).contains("OFFICIAL-SENSITIVE")
           Assertions.assertThat(text).contains("INTERNAL ONLY")
         }
       }


### PR DESCRIPTION
The security classification was duplicated on the contents page, being both in the main body and the footer.

This PR removes an instance.

Before:
![image](https://github.com/ministryofjustice/hmpps-subject-access-request-worker/assets/95350189/cab67a25-ba16-4fa5-aa80-2be091e81ef5)


After:
<img width="524" alt="image" src="https://github.com/ministryofjustice/hmpps-subject-access-request-worker/assets/95350189/3679e202-5150-494f-9632-911aad3c23f9">
