### PR TITLE
Update service order logic to handle null values

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GetSubjectAccessRequestDataService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GetSubjectAccessRequestDataService.kt
@@ -31,6 +31,20 @@ class GetSubjectAccessRequestDataService(@Autowired val genericHmppsApiGateway: 
   }
 
   fun order(services: List<DpsService>): List<DpsService> {
-    return services.sortedBy { it.orderPosition }
+    val servicesWithNoOrderPosition = mutableListOf<DpsService>()
+    val servicesWithOrderPosition = mutableListOf<DpsService>()
+
+    services.forEach { service ->
+      if (service.orderPosition != null) {
+        servicesWithOrderPosition.add(service)
+      } else {
+        servicesWithNoOrderPosition.add(service)
+      }
+    }
+
+    val servicesSortedByOrderPosition = servicesWithOrderPosition.sortedBy { it.orderPosition }
+    val servicesWithNoOrderPositionSortedByName = servicesWithNoOrderPosition.sortedBy { it.name }
+
+    return servicesSortedByOrderPosition + servicesWithNoOrderPositionSortedByName
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GetSubjectAccessRequestDataServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GetSubjectAccessRequestDataServiceTest.kt
@@ -109,6 +109,34 @@ class GetSubjectAccessRequestDataServiceTest(
         Assertions.assertThat(orderedDpsServices[1].orderPosition).isEqualTo(2)
         Assertions.assertThat(orderedDpsServices[2].orderPosition).isEqualTo(3)
       }
+
+      it("puts services with no order position last") {
+        val selectedDpsServices = mutableListOf(
+          DpsService(name = "fake-hmpps-prisoner-search", businessName = null, orderPosition = null, url = "https://fake-prisoner-search.prison.service.justice.gov.uk"),
+          DpsService(name = "fake-hmpps-prisoner-search-2", businessName = null, orderPosition = 2, url = "https://fake-prisoner-search-2.prison.service.justice.gov.uk"),
+          DpsService(name = "fake-hmpps-prisoner-search-indexer", businessName = null, orderPosition = 1, url = "https://fake-prisoner-search-indexer.prison.service.justice.gov.uk"),
+        )
+
+        val orderedDpsServices = getSubjectAccessRequestDataService.order(selectedDpsServices)
+
+        Assertions.assertThat(orderedDpsServices[0].orderPosition).isEqualTo(1)
+        Assertions.assertThat(orderedDpsServices[1].orderPosition).isEqualTo(2)
+        Assertions.assertThat(orderedDpsServices[2].orderPosition).isEqualTo(null)
+      }
+
+      it("sorts services with no order position alphabetically by name") {
+        val selectedDpsServices = mutableListOf(
+          DpsService(name = "service-B", businessName = null, orderPosition = null, url = "https://service-b.prison.service.justice.gov.uk"),
+          DpsService(name = "service-A", businessName = null, orderPosition = null, url = "https://service-a.prison.service.justice.gov.uk"),
+          DpsService(name = "service-C", businessName = null, orderPosition = null, url = "https://service-c.prison.service.justice.gov.uk"),
+        )
+
+        val orderedDpsServices = getSubjectAccessRequestDataService.order(selectedDpsServices)
+
+        Assertions.assertThat(orderedDpsServices[0].name).isEqualTo("service-A")
+        Assertions.assertThat(orderedDpsServices[1].name).isEqualTo("service-B")
+        Assertions.assertThat(orderedDpsServices[2].name).isEqualTo("service-C")
+      }
     }
   },
 )


### PR DESCRIPTION
This PR handles the ordering of services where the order position is not provided by the service config file.

Services are ordered first by the order position listed in the service config file. For services where no order position is provided, these are ordered alphabetically by service name, and then appended to the end of the ordered service list.

Service name, rather than service business name, is used for ordering, as the absence of an order position in the config file may imply that the service does not yet exist in the service config file (i.e., it is a new SAR endpoint picked up by the service catalogue that has not yet been added to the config file); in this case, the service will also not have a business name, as this is an attribute taken from the config file as well.