### PR TITLE
Header fixes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/models/CustomHeaderEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/models/CustomHeaderEventHandler.kt
@@ -24,7 +24,6 @@ class CustomHeaderEventHandler(private val pdfDoc: PdfDocument, val document: Do
       leftHeaderText = ""
       rightHeaderText = """
           |Name: $subjectName
-          |
           |$subjectIdLine
       """.trimMargin()
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/models/CustomHeaderEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/models/CustomHeaderEventHandler.kt
@@ -32,7 +32,7 @@ class CustomHeaderEventHandler(private val pdfDoc: PdfDocument, val document: Do
     val leftCoord = pageSize.left + document.leftMargin
     val rightCoord = pageSize.right - document.rightMargin
     val midCoord = (leftCoord + rightCoord) / 2
-    val headerY: Float = pageSize.top - document.topMargin - 10
+    val headerY: Float = pageSize.top - document.topMargin
     val footerY: Float = pageSize.bottom + 20
     val canvas = Canvas(docEvent.page, pageSize)
     canvas

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/models/CustomHeaderEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/models/CustomHeaderEventHandler.kt
@@ -43,13 +43,13 @@ class CustomHeaderEventHandler(private val pdfDoc: PdfDocument, val document: Do
         leftCoord,
         headerY,
         TextAlignment.LEFT,
-      )
+      ).setBold()
       .showTextAligned(
         rightHeaderText,
         rightCoord,
         headerY,
         TextAlignment.RIGHT,
-      )
+      ).setBold()
       .showTextAligned(
         "Official Sensitive",
         midCoord,


### PR DESCRIPTION
This PR makes the header higher up on the page to stop it overlapping with data text, and makes the text bold. 
It isn't easily possible to make part of the header bold so I opted to make the whole thing bold.

Before:
![image](https://github.com/user-attachments/assets/611aa7ab-3c4d-458f-adfc-03840edc44c8)


After:
![image](https://github.com/user-attachments/assets/b5ea82dc-8633-49ff-a033-6db6b5738f17)
