### PR TITLE
Update PDF margins

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/GeneratePdfService.kt
@@ -82,7 +82,7 @@ class GeneratePdfService {
         subjectName,
       ),
     )
-    document.setMargins(50F, 50F, 100F, 50F)
+    document.setMargins(50F, 35F, 70F, 35F)
     addData(pdfDocument, document, services)
     val numPages = pdfDocument.numberOfPages
     addRearPage(pdfDocument, document, numPages)


### PR DESCRIPTION
### Context

Margin settings have been causing some formatting oddities whereby content appears too close to the right hand side. This PR is to normalise the horizontal alignment.
