### PR TITLE
Catch exceptions with the name lookup and replace with 'No subject name found'

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatusCode
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestworker.config.trackEvent
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestworker.gateways.DocumentStorageGateway
 import uk.gov.justice.digital.hmpps.hmppssubjectaccessrequestworker.gateways.PrisonApiGateway
@@ -93,7 +94,7 @@ class SubjectAccessRequestWorkerService(
     var subjectName: String
     try {
       subjectName = getSubjectName(chosenSAR.nomisId, chosenSAR.ndeliusCaseReferenceId)
-    } catch (exception: Exception) {
+    } catch (exception: WebClientResponseException.NotFound) {
       subjectName = "No subject name found"
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppssubjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
@@ -90,7 +90,12 @@ class SubjectAccessRequestWorkerService(
     val dpsServiceList = getSubjectAccessRequestDataService.execute(selectedServices, chosenSAR.nomisId, chosenSAR.ndeliusCaseReferenceId, chosenSAR.dateFrom, chosenSAR.dateTo)
 
     log.info("Fetching subject name")
-    val subjectName = getSubjectName(chosenSAR.nomisId, chosenSAR.ndeliusCaseReferenceId)
+    var subjectName: String
+    try {
+      subjectName = getSubjectName(chosenSAR.nomisId, chosenSAR.ndeliusCaseReferenceId)
+    } catch (exception: Exception) {
+      subjectName = "No subject name found"
+    }
 
     log.info("Extracted report")
 


### PR DESCRIPTION
This is to catch the issue where no name is found, the process errors, and the request is stuck in an error loop. Putting "No name found" should make it clear to the users that the ID they entered doesn't refer to a prisoner. 