### PR TITLE
 HAAR-3282 added additional details to exception message to aid debugging

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/exception/SubjectAccessRequestException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/exception/SubjectAccessRequestException.kt
@@ -25,6 +25,6 @@ open class SubjectAccessRequestException(
     }
 
   private fun Map<String, *>.toFormattedString() = this.entries.joinToString(", ") { entry ->
-    "${entry.key}=${entry.value.toString()}"
+    "${entry.key}=${entry.value}"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/exception/SubjectAccessRequestException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/exception/SubjectAccessRequestException.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception
 
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent
-import java.net.URI
 import java.util.UUID
 
 open class SubjectAccessRequestException(
@@ -14,24 +13,18 @@ open class SubjectAccessRequestException(
 
   constructor(message: String) : this(message, null, null, null)
 
+  /**
+   * Return the exception message with additional details.
+   */
   override val message: String?
-    get() {
-      val formattedParams = params?.toFormattedString()
-      if (formattedParams.isNullOrEmpty()) {
-        return "${super.message}, event=$event, id=$subjectAccessRequestId"
-      }
-
-      return "${super.message}, event=$event, id=$subjectAccessRequestId, $formattedParams"
+    get() = buildString {
+      append(super.message)
+      cause?.message?.let { append(", cause=$it") }
+      append(", event=$event, id=$subjectAccessRequestId")
+      params?.toFormattedString()?.let { append(", $it") }
     }
 
   private fun Map<String, *>.toFormattedString() = this.entries.joinToString(", ") { entry ->
-    val value = entry.value
-    val second = if (value is URI) {
-      // Return URI without the query string
-      "${value.scheme}://${value.host}:${value.port}${value.path}"
-    } else {
-      entry.value.toString()
-    }
-    "${entry.key}=$second"
+    "${entry.key}=${entry.value.toString()}"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
@@ -64,7 +64,13 @@ class SubjectAccessRequestWorkerService(
       stopWatch.stop()
       telemetryClient.trackSarEvent("NewReportClaimComplete", subjectAccessRequest, TIME_ELAPSED_KEY to stopWatch.time.toString())
     } catch (exception: Exception) {
-      log.error("subjectAccessRequest: ${subjectAccessRequest?.id} failed with error: ${exception.message}", exception)
+      val errorMessage = buildString {
+        append("subjectAccessRequest ")
+        subjectAccessRequest?.id?.let { append("id=$it" ) }
+        subjectAccessRequest?.sarCaseReferenceNumber?.let { append("sarCaseReferenceNumber=$it" ) }
+        append("failed with error: ${exception.message}")
+      }
+      log.error(errorMessage, exception)
 
       telemetryClient.trackSarEvent(
         "ReportFailedWithError",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
@@ -66,8 +66,8 @@ class SubjectAccessRequestWorkerService(
     } catch (exception: Exception) {
       val errorMessage = buildString {
         append("subjectAccessRequest ")
-        subjectAccessRequest?.id?.let { append("id=$it" ) }
-        subjectAccessRequest?.sarCaseReferenceNumber?.let { append("sarCaseReferenceNumber=$it" ) }
+        subjectAccessRequest?.id?.let { append("id=$it ") }
+        subjectAccessRequest?.sarCaseReferenceNumber?.let { append("sarCaseReferenceNumber=$it ") }
         append("failed with error: ${exception.message}")
       }
       log.error(errorMessage, exception)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/utils/WebClientRetriesSpec.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/utils/WebClientRetriesSpec.kt
@@ -37,7 +37,7 @@ class WebClientRetriesSpec(webClientConfiguration: WebClientConfiguration) {
       .backoff(maxRetries, backOff)
       .filter { err -> is5xxOrClientRequestError(err) }
       .doBeforeRetry { signal ->
-        LOG.error("subject access request $event failed with error=${signal.failure()}, attempting retry after backoff: $backOff, ${params?.formatted()}")
+        LOG.error("subject access request $event, id=$subjectAccessRequestId failed with error=${signal.failure()}, attempting retry after backoff: $backOff, ${params?.formatted()}")
       }
       .onRetryExhaustedThrow { _, signal ->
         SubjectAccessRequestRetryExhaustedException(
@@ -78,6 +78,6 @@ class WebClientRetriesSpec(webClientConfiguration: WebClientConfiguration) {
     }
 
   private fun Map<String, Any>.formatted(): String {
-    return "${this.entries.joinToString(",") { "${it.key}=${it.value}" }}"
+    return this.entries.joinToString(",") { "${it.key}=${it.value}" }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/SubjectAccessRequestExceptionTestUtil.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/SubjectAccessRequestExceptionTestUtil.kt
@@ -6,6 +6,7 @@ fun assertExpectedErrorMessage(actual: Throwable, prefix: String, vararg params:
   val formattedParams = params.joinToString(", ") { entry ->
     "${entry.first}=${entry.second}"
   }
-  val expected = "$prefix $formattedParams"
-  assertThat(actual.message).isEqualTo(expected)
+
+  assertThat(actual.message).startsWith(prefix)
+  assertThat(actual.message).endsWith(formattedParams)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/SubjectAccessRequestGatewayIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/SubjectAccessRequestGatewayIntTest.kt
@@ -112,7 +112,7 @@ class SubjectAccessRequestGatewayIntTest : IntegrationTestBase() {
         prefix = "subjectAccessRequest failed with non-retryable error: client 4xx response status,",
         "event" to "GET_UNCLAIMED_REQUESTS",
         "id" to null,
-        "uri" to "${subjectAccessRequestApiMock.baseUrl()}/api/subjectAccessRequests",
+        "uri" to "${subjectAccessRequestApiMock.baseUrl()}/api/subjectAccessRequests?unclaimed=true",
         "httpStatus" to HttpStatus.UNAUTHORIZED,
       )
 
@@ -130,7 +130,7 @@ class SubjectAccessRequestGatewayIntTest : IntegrationTestBase() {
         prefix = "subjectAccessRequest failed with non-retryable error: client 4xx response status,",
         "event" to "GET_UNCLAIMED_REQUESTS",
         "id" to null,
-        "uri" to "${subjectAccessRequestApiMock.baseUrl()}/api/subjectAccessRequests",
+        "uri" to "${subjectAccessRequestApiMock.baseUrl()}/api/subjectAccessRequests?unclaimed=true",
         "httpStatus" to HttpStatus.FORBIDDEN,
       )
 
@@ -148,7 +148,7 @@ class SubjectAccessRequestGatewayIntTest : IntegrationTestBase() {
         prefix = "subjectAccessRequest failed with non-retryable error: client 4xx response status,",
         "event" to "GET_UNCLAIMED_REQUESTS",
         "id" to null,
-        "uri" to "${subjectAccessRequestApiMock.baseUrl()}/api/subjectAccessRequests",
+        "uri" to "${subjectAccessRequestApiMock.baseUrl()}/api/subjectAccessRequests?unclaimed=true",
         "httpStatus" to HttpStatus.UNAUTHORIZED,
       )
 
@@ -453,13 +453,5 @@ class SubjectAccessRequestGatewayIntTest : IntegrationTestBase() {
 
       subjectAccessRequestApiMock.verifyZeroInteractions()
     }
-  }
-
-  private fun assertExpectedErrorMessage(actual: Throwable, prefix: String, vararg params: Pair<String, *>) {
-    val formattedParams = params.joinToString(", ") { entry ->
-      "${entry.first}=${entry.second}"
-    }
-    val expected = "$prefix $formattedParams"
-    assertThat(actual.message).isEqualTo(expected)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/mockservers/DocumentApiMockExtension.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/mockservers/DocumentApiMockExtension.kt
@@ -156,7 +156,7 @@ class DocumentApiMockServer : WireMockServer(8084) {
       "documentUuid": "$subjectAccessRequestId",
       "documentType": "Subject Access Request",
       "documentFilename": "Subject Access Request - $subjectAccessRequestId",
-      "filename": ""Subject Access Request - $subjectAccessRequestId.pdf",
+      "filename": "Subject Access Request - $subjectAccessRequestId.pdf",
       "fileExtension": "pdf",
       "fileSize": 1,
       "fileHash": "1",


### PR DESCRIPTION
- Added url parameters to exception details for service requests to get SAR data.
- Included cause in exception message to help with visibility of underlying issues and aid debugging.