### PR TITLE
added fix to ignore document store conflict errors

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/exception/SubjectAccessRequestDocumentStoreConflictException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/exception/SubjectAccessRequestDocumentStoreConflictException.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception
+
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent
+import java.util.UUID
+
+class SubjectAccessRequestDocumentStoreConflictException(
+  subjectAccessRequestId: UUID? = null,
+  params: Map<String, *>? = null,
+) : SubjectAccessRequestException(
+  "subject access request document store upload unsuccessful: document already exists",
+  null,
+  ProcessingEvent.STORE_DOCUMENT,
+  subjectAccessRequestId,
+  params,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/gateways/GenericHmppsApiGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/gateways/GenericHmppsApiGateway.kt
@@ -92,14 +92,14 @@ class GenericHmppsApiGateway(
       webClientRetriesSpec.is4xxStatus(),
       webClientRetriesSpec.throw4xxStatusFatalError(
         GET_SAR_DATA,
-        subjectAccessRequest?.id,
+        subjectAccessRequest,
       ),
     )
     .toEntity(Map::class.java)
     .retryWhen(
       webClientRetriesSpec.retry5xxAndClientRequestErrors(
         GET_SAR_DATA,
-        subjectAccessRequest?.id,
+        subjectAccessRequest,
         mapOf(
           "uri" to serviceUrl,
         ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
@@ -158,9 +158,8 @@ class SubjectAccessRequestWorkerService(
   }
 
   /**
-   * Attempt to upload the document to the DocumentStore. If a document with the specified ID already exists the subject
-   * access request no action will be taken. The "new" document will not be uploaded and the SAR request will complete
-   * quietly.
+   * Attempt to upload the document to the DocumentStore. If a document with the specified ID already exists no action
+   * will be taken. The "new" document will not be uploaded and the SAR request will marked complete.
    */
   fun uploadToDocumentStore(
     stopWatch: StopWatch,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/utils/WebClientRetriesSpec.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/utils/WebClientRetriesSpec.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils
 
+import com.microsoft.applicationinsights.TelemetryClient
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.ClientResponse
@@ -10,41 +12,55 @@ import reactor.core.publisher.Mono
 import reactor.util.retry.Retry
 import reactor.util.retry.RetryBackoffSpec
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.config.WebClientConfiguration
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.config.trackSarEvent
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.FatalSubjectAccessRequestException
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.SubjectAccessRequestDocumentStoreConflictException
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.SubjectAccessRequestException
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.SubjectAccessRequestRetryExhaustedException
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAccessRequest
+import java.net.URI
 import java.time.Duration
-import java.util.UUID
 import java.util.function.Predicate
 
 @Component
-class WebClientRetriesSpec(webClientConfiguration: WebClientConfiguration) {
+class WebClientRetriesSpec(
+  webClientConfiguration: WebClientConfiguration,
+  val telemetryClient: TelemetryClient,
+) {
 
   private val maxRetries: Long = webClientConfiguration.maxRetries
   private val backOff: Duration = webClientConfiguration.getBackoffDuration()
 
   companion object {
     private val LOG = LoggerFactory.getLogger(WebClientRetriesSpec::class.java)
+    private const val DOCUMENT_STORE_CONFLICT_EVENT = "DocumentStoreConflictError"
+    private const val NON_RETRYABLE_CLIENT_ERROR_EVENT = "NonRetryableClientError"
+    private const val CLIENT_RETRIES_EXHAUSTED_ERROR_EVENT = "ClientRetriesExhaustedError"
   }
 
   fun retry5xxAndClientRequestErrors(
     event: ProcessingEvent,
-    subjectAccessRequestId: UUID?,
+    subjectAccessRequest: SubjectAccessRequest?,
     params: Map<String, Any>? = null,
   ): RetryBackoffSpec {
     return Retry
       .backoff(maxRetries, backOff)
       .filter { err -> is5xxOrClientRequestError(err) }
       .doBeforeRetry { signal ->
-        LOG.error("subject access request $event, id=$subjectAccessRequestId failed with error=${signal.failure()}, attempting retry after backoff: $backOff, ${params?.formatted()}")
+        LOG.error(
+          "subject access request $event, id=${subjectAccessRequest?.id} failed with " +
+            "error=${signal.failure()}, attempting retry after backoff: $backOff, ${params?.formatted()}",
+        )
       }
       .onRetryExhaustedThrow { _, signal ->
+        telemetryClient.clientRetriesExhausted(subjectAccessRequest, signal, event)
+
         SubjectAccessRequestRetryExhaustedException(
           retryAttempts = signal.totalRetries(),
           cause = signal.failure(),
           event = event,
-          subjectAccessRequestId = subjectAccessRequestId,
+          subjectAccessRequestId = subjectAccessRequest?.id,
           params = params,
         )
       }
@@ -58,7 +74,7 @@ class WebClientRetriesSpec(webClientConfiguration: WebClientConfiguration) {
 
   fun throw4xxStatusFatalError(
     event: ProcessingEvent,
-    subjectAccessRequestId: UUID?,
+    subjectAccessRequest: SubjectAccessRequest?,
     params: Map<String, Any>? = null,
   ) =
     { response: ClientResponse ->
@@ -66,18 +82,83 @@ class WebClientRetriesSpec(webClientConfiguration: WebClientConfiguration) {
         map.putIfAbsent("uri", response.request().uri)
         map.putIfAbsent("httpStatus", response.statusCode())
       }
+      telemetryClient.nonRetryableClientError(subjectAccessRequest, event, params)
 
       Mono.error<SubjectAccessRequestException>(
         FatalSubjectAccessRequestException(
           message = "client 4xx response status",
           event = event,
-          subjectAccessRequestId = subjectAccessRequestId,
+          subjectAccessRequestId = subjectAccessRequest?.id,
           params = moddedParams,
         ),
       )
     }
 
+  fun is409Conflict(): Predicate<HttpStatusCode> =
+    Predicate<HttpStatusCode> { code: HttpStatusCode -> HttpStatus.CONFLICT.isSameCodeAs(code) }
+
+  fun throwDocumentApiConflictException(subjectAccessRequest: SubjectAccessRequest) = { response: ClientResponse ->
+    telemetryClient.documentStoreConflictError(subjectAccessRequest, response.request().uri)
+
+    Mono.error<SubjectAccessRequestException>(
+      SubjectAccessRequestDocumentStoreConflictException(
+        subjectAccessRequestId = subjectAccessRequest.id,
+        mapOf(
+          "uri" to response.request().uri,
+          "httpStatus" to response.statusCode(),
+        ),
+      ),
+    )
+  }
+
   private fun Map<String, Any>.formatted(): String {
     return this.entries.joinToString(",") { "${it.key}=${it.value}" }
+  }
+
+  fun TelemetryClient.clientRetriesExhausted(
+    subjectAccessRequest: SubjectAccessRequest?,
+    signal: Retry.RetrySignal,
+    event: ProcessingEvent,
+  ) {
+    telemetryClient.trackSarEvent(
+      CLIENT_RETRIES_EXHAUSTED_ERROR_EVENT,
+      subjectAccessRequest,
+      "retryAttempts" to signal.totalRetries().toString(),
+      "cause" to (signal.failure().cause?.message ?: "null"),
+      "event" to event.name,
+    )
+  }
+
+  fun TelemetryClient.nonRetryableClientError(
+    subjectAccessRequest: SubjectAccessRequest?,
+    event: ProcessingEvent,
+    params: Map<String, Any>? = null,
+  ) {
+    val kvPairs = mutableListOf(
+      Pair("event", event.name),
+    )
+    // Convert params to list of pair<String, String>
+    params?.entries?.forEach { entry ->
+      kvPairs.add(Pair(entry.key, entry.value.toString()))
+    }
+
+    telemetryClient.trackSarEvent(
+      NON_RETRYABLE_CLIENT_ERROR_EVENT,
+      subjectAccessRequest,
+      "event" to event.name,
+      *kvPairs.toTypedArray(),
+    )
+  }
+
+  fun TelemetryClient.documentStoreConflictError(
+    subjectAccessRequest: SubjectAccessRequest?,
+    uri: URI,
+  ) {
+    telemetryClient.trackSarEvent(
+      DOCUMENT_STORE_CONFLICT_EVENT,
+      subjectAccessRequest,
+      "event" to ProcessingEvent.STORE_DOCUMENT.name,
+      "uri" to uri.toString(),
+    )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/mockservers/DocumentApiMockExtension.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/mockservers/DocumentApiMockExtension.kt
@@ -68,6 +68,24 @@ class DocumentApiMockServer : WireMockServer(8084) {
     )
   }
 
+  fun stubUploadFileReturnsInvalidResponseEntity(subjectAccessRequestId: String, expectedFileContent: ByteArray) {
+    stubFor(
+      post(urlPathEqualTo("/documents/SUBJECT_ACCESS_REQUEST_REPORT/$subjectAccessRequestId"))
+        .withHeader("Service-Name", equalTo(SERVICE_NAME_HEADER))
+        .withMultipartRequestBody(
+          aMultipart()
+            .withName("report.pdf")
+            .withBody(binaryEqualTo(expectedFileContent)),
+        )
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200)
+            .withBody("[17]"),
+        ),
+    )
+  }
+
   fun stubUploadFileFailsWithStatus(
     subjectAccessRequestId: String,
     expectedFileContent: ByteArray,


### PR DESCRIPTION
Updated documentAPI client to throw specific exception on 409/conflict status. SAR worker now treats existing document error as "no action required" allowing the job to complete preventing it entering a doom loop.

Added additional error logging/handling to aid debugging invalid document API response body issue.

