### PR TITLE
fix issue with PostDocumentResponseEntity to handle metadata values o…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/DocumentStorageClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/DocumentStorageClient.kt
@@ -53,7 +53,6 @@ class DocumentStorageClient(
         .bodyValue(
           MultipartBodyBuilder().apply {
             part("file", contentsAsResource)
-            part("metadata", 1)
           }.build(),
         )
         .retrieve()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/DocumentStorageClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/DocumentStorageClient.kt
@@ -161,7 +161,7 @@ class DocumentStorageClient(
     val fileSize: Int? = null,
     val fileHash: String? = null,
     val mimeType: String? = null,
-    val metadata: Map<String, Any>? = null,
+    val metadata: Any? = null,
     val createdTime: String? = null,
     val createdByServiceName: String? = null,
     val createdByUsername: String? = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/mockservers/DocumentApiMockExtension.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/mockservers/DocumentApiMockExtension.kt
@@ -222,20 +222,22 @@ class DocumentApiMockServer : WireMockServer(8084) {
     fileContent: ByteArray,
     metadata: Any?,
   ): String {
-    return Gson().toJson(DocumentStorageClient.PostDocumentResponse(
-      documentUuid = subjectAccessRequestId,
-      documentType = "Subject Access Request",
-      documentFilename = "Subject Access Request - $subjectAccessRequestId",
-      filename = "Subject Access Request - $subjectAccessRequestId.pdf",
-      fileExtension = "pdf",
-      fileSize = fileSize,
-      fileHash = fileHash(fileContent),
-      mimeType = "pdf",
-      metadata = metadata,
-      createdTime = "2024-10-29T16:15:58.590Z",
-      createdByServiceName = SERVICE_NAME_HEADER,
-      createdByUsername = "Robert Bobby"
-    ))
+    return Gson().toJson(
+      DocumentStorageClient.PostDocumentResponse(
+        documentUuid = subjectAccessRequestId,
+        documentType = "Subject Access Request",
+        documentFilename = "Subject Access Request - $subjectAccessRequestId",
+        filename = "Subject Access Request - $subjectAccessRequestId.pdf",
+        fileExtension = "pdf",
+        fileSize = fileSize,
+        fileHash = fileHash(fileContent),
+        mimeType = "pdf",
+        metadata = metadata,
+        createdTime = "2024-10-29T16:15:58.590Z",
+        createdByServiceName = SERVICE_NAME_HEADER,
+        createdByUsername = "Robert Bobby",
+      ),
+    )
   }
 
   fun verifyNeverCalled() {


### PR DESCRIPTION
Fixed issue with document API response marshalling. Metadata can be any object type so updated structure to allow Any + added tests to prove it can handle different types.