### PR TITLE
refactor tests to be less brittle

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/DocumentStorageClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/DocumentStorageClient.kt
@@ -89,10 +89,7 @@ class DocumentStorageClient(
         message = "documentStoreClient error authorization exception",
         cause = ex,
         event = STORE_DOCUMENT,
-        subjectAccessRequestId = subjectAccessRequestId,
-        params = mapOf(
-          "cause" to ex.cause?.message,
-        ),
+        subjectAccessRequest = subjectAccessRequest,
       )
     } catch (ex: Exception) {
       if (ex is SubjectAccessRequestException) {
@@ -104,7 +101,7 @@ class DocumentStorageClient(
         message = "documentStoreClient unexpected error",
         cause = ex,
         event = STORE_DOCUMENT,
-        subjectAccessRequestId = subjectAccessRequestId,
+        subjectAccessRequest = subjectAccessRequest,
       )
     }
   }
@@ -119,7 +116,7 @@ class DocumentStorageClient(
         message = "document store upload error: response body expected but was null",
         cause = null,
         event = STORE_DOCUMENT,
-        subjectAccessRequestId = subjectAccessRequest.id,
+        subjectAccessRequest = subjectAccessRequest,
       )
     }
 
@@ -137,7 +134,7 @@ class DocumentStorageClient(
         message = "document store upload error: response file size did not match the expected file upload size",
         cause = null,
         event = STORE_DOCUMENT,
-        subjectAccessRequestId = subjectAccessRequest.id,
+        subjectAccessRequest = subjectAccessRequest,
         params = mapOf(
           "expectedFileSize" to expectedFileSize,
           "actualFileSize" to postDocumentResponse.fileSize,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/PrisonApiClient.kt
@@ -51,7 +51,7 @@ class PrisonApiClient(
         message = "prisonApiClient error authorization exception",
         cause = ex,
         event = ACQUIRE_AUTH_TOKEN,
-        subjectAccessRequestId = subjectAccessRequest.id,
+        subjectAccessRequest = subjectAccessRequest,
         params = mapOf(
           "cause" to ex.cause?.message,
         ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/ProbationApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/ProbationApiClient.kt
@@ -54,7 +54,7 @@ class ProbationApiClient(
         message = "probationApiClient error authorization exception",
         cause = ex,
         event = ACQUIRE_AUTH_TOKEN,
-        subjectAccessRequestId = subjectAccessRequest.id,
+        subjectAccessRequest = subjectAccessRequest,
         params = mapOf(
           "cause" to ex.cause?.message,
         ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/config/ApplicationInsightsConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/config/ApplicationInsightsConfiguration.kt
@@ -14,15 +14,24 @@ class ApplicationInsightsConfiguration {
   fun telemetryClient(): TelemetryClient = TelemetryClient()
 }
 
+const val UNKNOWN_PLACEHOLDER = "unknown"
+
 fun TelemetryClient.trackEvent(name: String, properties: Map<String, String>) = this.trackEvent(name, properties, null)
 
-fun TelemetryClient.trackSarEvent(name: String, subjectAccessRequest: SubjectAccessRequest?, vararg kvpairs: Pair<String, String>) {
-  val id = subjectAccessRequest?.sarCaseReferenceNumber ?: "unknown"
+fun TelemetryClient.trackSarEvent(
+  name: String,
+  subjectAccessRequest: SubjectAccessRequest?,
+  vararg kvpairs: Pair<String, String>,
+) {
+  val id = subjectAccessRequest?.sarCaseReferenceNumber ?: UNKNOWN_PLACEHOLDER
+  val contextId = subjectAccessRequest?.contextId.toString()
+
   this.trackEvent(
     name,
     mapOf(
       "sarId" to id,
       "UUID" to subjectAccessRequest?.id.toString(),
+      "contextId" to contextId,
       *kvpairs,
     ),
     null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/exception/FatalSubjectAccessRequestException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/exception/FatalSubjectAccessRequestException.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception
 
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent
-import java.util.UUID
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAccessRequest
 
 private const val FATAL_ERROR_MESSAGE_PREFIX = "subjectAccessRequest failed with non-retryable error: %s"
 
@@ -12,20 +12,20 @@ class FatalSubjectAccessRequestException(
   message: String,
   cause: Throwable?,
   event: ProcessingEvent,
-  subjectAccessRequestId: UUID? = null,
+  subjectAccessRequest: SubjectAccessRequest? = null,
   params: Map<String, *>? = null,
 ) : SubjectAccessRequestException(
   FATAL_ERROR_MESSAGE_PREFIX.format(message),
   cause,
   event,
-  subjectAccessRequestId,
+  subjectAccessRequest,
   params,
 ) {
 
   constructor(
     message: String,
     event: ProcessingEvent,
-    subjectAccessRequestId: UUID? = null,
+    subjectAccessRequest: SubjectAccessRequest? = null,
     params: Map<String, *>? = null,
-  ) : this(message, null, event, subjectAccessRequestId, params)
+  ) : this(message, null, event, subjectAccessRequest, params)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/exception/SubjectAccessRequestDocumentStoreConflictException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/exception/SubjectAccessRequestDocumentStoreConflictException.kt
@@ -1,15 +1,15 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception
 
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent
-import java.util.UUID
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAccessRequest
 
 class SubjectAccessRequestDocumentStoreConflictException(
-  subjectAccessRequestId: UUID? = null,
+  subjectAccessRequest: SubjectAccessRequest? = null,
   params: Map<String, *>? = null,
 ) : SubjectAccessRequestException(
   "subject access request document store upload unsuccessful: document already exists",
   null,
   ProcessingEvent.STORE_DOCUMENT,
-  subjectAccessRequestId,
+  subjectAccessRequest,
   params,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/exception/SubjectAccessRequestException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/exception/SubjectAccessRequestException.kt
@@ -1,14 +1,14 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception
 
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent
-import java.util.UUID
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAccessRequest
 
 open class SubjectAccessRequestException(
   message: String,
   cause: Throwable? = null,
-  private val event: ProcessingEvent?,
-  private val subjectAccessRequestId: UUID? = null,
-  private val params: Map<String, *>? = null,
+  val event: ProcessingEvent?,
+  val subjectAccessRequest: SubjectAccessRequest? = null,
+  val params: Map<String, *>? = null,
 ) : RuntimeException(message, cause) {
 
   constructor(message: String) : this(message, null, null, null)
@@ -20,7 +20,7 @@ open class SubjectAccessRequestException(
     get() = buildString {
       append(super.message)
       cause?.message?.let { append(", cause=$it") }
-      append(", event=$event, id=$subjectAccessRequestId")
+      append(", event=$event, id=${subjectAccessRequest?.id}, contextId=${subjectAccessRequest?.contextId}")
       params?.toFormattedString()?.let { append(", $it") }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/exception/SubjectAccessRequestRetryExhaustedException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/exception/SubjectAccessRequestRetryExhaustedException.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception
 
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent
-import java.util.UUID
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAccessRequest
 
 private const val ERROR_MESSAGE_PREFIX = "subjectAccessRequest failed and max retry attempts (%s) exhausted"
 
@@ -12,14 +12,20 @@ class SubjectAccessRequestRetryExhaustedException(
   retryAttempts: Long,
   cause: Throwable?,
   event: ProcessingEvent,
-  subjectAccessRequestId: UUID? = null,
+  subjectAccessRequest: SubjectAccessRequest? = null,
   params: Map<String, *>? = null,
-) : SubjectAccessRequestException(ERROR_MESSAGE_PREFIX.format(retryAttempts), cause, event, subjectAccessRequestId, params) {
+) : SubjectAccessRequestException(
+  ERROR_MESSAGE_PREFIX.format(retryAttempts),
+  cause,
+  event,
+  subjectAccessRequest,
+  params,
+) {
 
   constructor(
     retryAttempts: Long,
     event: ProcessingEvent,
-    subjectAccessRequestId: UUID? = null,
+    subjectAccessRequest: SubjectAccessRequest? = null,
     params: Map<String, *>? = null,
-  ) : this(retryAttempts, null, event, subjectAccessRequestId, params)
+  ) : this(retryAttempts, null, event, subjectAccessRequest, params)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/gateways/GenericHmppsApiGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/gateways/GenericHmppsApiGateway.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAcc
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.WebClientRetriesSpec
 import java.time.LocalDate
 import java.util.Optional
-import java.util.UUID
 
 @Component
 class GenericHmppsApiGateway(
@@ -43,7 +42,7 @@ class GenericHmppsApiGateway(
     dateTo: LocalDate? = null,
     subjectAccessRequest: SubjectAccessRequest? = null,
   ): Map<*, *>? {
-    val clientToken = getAuthToken(subjectAccessRequest?.id, serviceUrl)
+    val clientToken = getAuthToken(subjectAccessRequest, serviceUrl)
 
     val stopWatch = StopWatch.createStarted()
     telemetryClient.dataRequestStarted(subjectAccessRequest, serviceUrl)
@@ -106,7 +105,7 @@ class GenericHmppsApiGateway(
       ),
     ).block()
 
-  fun getAuthToken(subjectAccessRequestId: UUID?, serviceUrl: String): String {
+  fun getAuthToken(subjectAccessRequest: SubjectAccessRequest?, serviceUrl: String): String {
     try {
       return authGateway.getClientToken()
     } catch (ex: Exception) {
@@ -114,7 +113,7 @@ class GenericHmppsApiGateway(
         message = "failed to obtain client auth token",
         cause = ex,
         event = GET_SAR_DATA,
-        subjectAccessRequestId = subjectAccessRequestId,
+        subjectAccessRequest = subjectAccessRequest,
         mapOf("serviceUrl" to serviceUrl),
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/gateways/HmppsAuthGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/gateways/HmppsAuthGateway.kt
@@ -43,7 +43,7 @@ class HmppsAuthGateway(
       message = "authGateway get auth token WebclientResponseException",
       cause = cause,
       event = ACQUIRE_AUTH_TOKEN,
-      subjectAccessRequestId = null,
+      subjectAccessRequest = null,
       params = mapOf(
         "authority" to cause.request?.uri?.authority,
         "httpStatus" to cause.statusCode.value(),
@@ -55,7 +55,7 @@ class HmppsAuthGateway(
     message = "authGateway get auth token unexpected error",
     cause = cause,
     event = ACQUIRE_AUTH_TOKEN,
-    subjectAccessRequestId = null,
+    subjectAccessRequest = null,
     params = mapOf(
       "host" to hmppsAuthUrl,
     ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/gateways/SubjectAccessRequestGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/gateways/SubjectAccessRequestGateway.kt
@@ -1,34 +1,19 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.gateways
 
-import org.springframework.http.HttpStatusCode
 import org.springframework.stereotype.Service
-import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.reactive.function.client.WebClientRequestException
-import org.springframework.web.reactive.function.client.WebClientResponseException
-import reactor.core.publisher.Mono
-import reactor.util.retry.Retry
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.config.WebClientConfiguration
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent.CLAIM_REQUEST
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent.COMPLETE_REQUEST
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent.GET_UNCLAIMED_REQUESTS
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.FatalSubjectAccessRequestException
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.SubjectAccessRequestException
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.SubjectAccessRequestRetryExhaustedException
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAccessRequest
-import java.time.Duration
-import java.util.UUID
-import java.util.function.Predicate
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.WebClientRetriesSpec
 
 @Service
 class SubjectAccessRequestGateway(
   val hmppsAuthGateway: HmppsAuthGateway,
-  webClientConfig: WebClientConfiguration,
+  val webClientRetriesSpec: WebClientRetriesSpec,
 ) {
-
-  private val backoff: Duration = webClientConfig.getBackoffDuration()
-  private val maxRetries: Long = webClientConfig.maxRetries
 
   fun getClient(url: String): WebClient {
     return WebClient.create(url) // TODO what other config does this need?
@@ -47,17 +32,12 @@ class SubjectAccessRequestGateway(
       .header("Authorization", "Bearer $token")
       .retrieve()
       .onStatus(
-        is4xxStatus(),
-        handle4xxStatus(subjectAccessRequest = null, event = GET_UNCLAIMED_REQUESTS),
+        webClientRetriesSpec.is4xxStatus(),
+        webClientRetriesSpec.throw4xxStatusFatalError(event = GET_UNCLAIMED_REQUESTS),
       )
       .bodyToMono(Array<SubjectAccessRequest>::class.java)
       .retryWhen(
-        Retry
-          .backoff(maxRetries, backoff)
-          .filter { error -> isRetryableError(error) }
-          .onRetryExhaustedThrow { _, signal ->
-            retriesExhaustedException(signal, GET_UNCLAIMED_REQUESTS, null)
-          },
+        webClientRetriesSpec.retry5xxAndClientRequestErrors(event = GET_UNCLAIMED_REQUESTS),
       ).block()
   }
 
@@ -75,17 +55,12 @@ class SubjectAccessRequestGateway(
       .header("Authorization", "Bearer $token")
       .retrieve()
       .onStatus(
-        is4xxStatus(),
-        handle4xxStatus(subjectAccessRequest = subjectAccessRequest, event = CLAIM_REQUEST),
+        webClientRetriesSpec.is4xxStatus(),
+        webClientRetriesSpec.throw4xxStatusFatalError(CLAIM_REQUEST, subjectAccessRequest),
       )
       .toBodilessEntity()
       .retryWhen(
-        Retry
-          .backoff(maxRetries, backoff)
-          .filter { error -> isRetryableError(error) }
-          .onRetryExhaustedThrow { _, signal ->
-            retriesExhaustedException(signal, CLAIM_REQUEST, subjectAccessRequestId)
-          },
+        webClientRetriesSpec.retry5xxAndClientRequestErrors(CLAIM_REQUEST, subjectAccessRequest),
       ).block()
   }
 
@@ -99,51 +74,12 @@ class SubjectAccessRequestGateway(
       .header("Authorization", "Bearer $token")
       .retrieve()
       .onStatus(
-        is4xxStatus(),
-        handle4xxStatus(subjectAccessRequest = subjectAccessRequest, event = COMPLETE_REQUEST),
+        webClientRetriesSpec.is4xxStatus(),
+        webClientRetriesSpec.throw4xxStatusFatalError(COMPLETE_REQUEST, subjectAccessRequest),
       )
       .toBodilessEntity()
       .retryWhen(
-        Retry.backoff(maxRetries, backoff)
-          .filter { error -> isRetryableError(error) }
-          .onRetryExhaustedThrow { _, signal ->
-            retriesExhaustedException(signal, COMPLETE_REQUEST, subjectAccessRequestId)
-          },
+        webClientRetriesSpec.retry5xxAndClientRequestErrors(COMPLETE_REQUEST, subjectAccessRequest),
       ).block()
   }
-
-  private fun is4xxStatus(): Predicate<HttpStatusCode> =
-    Predicate<HttpStatusCode> { code: HttpStatusCode -> code.is4xxClientError }
-
-  private fun handle4xxStatus(subjectAccessRequest: SubjectAccessRequest?, event: ProcessingEvent) =
-    { response: ClientResponse ->
-      Mono.error<SubjectAccessRequestException>(
-        FatalSubjectAccessRequestException(
-          message = "client 4xx response status",
-          event = event,
-          subjectAccessRequestId = subjectAccessRequest?.id,
-          params = mapOf(
-            "uri" to response.request().uri,
-            "httpStatus" to response.statusCode(),
-          ),
-        ),
-      )
-    }
-
-  private fun retriesExhaustedException(
-    signal: Retry.RetrySignal,
-    event: ProcessingEvent,
-    subjectAccessRequestId: UUID?,
-  ) = SubjectAccessRequestRetryExhaustedException(
-    retryAttempts = signal.totalRetries(),
-    cause = signal.failure(),
-    event = event,
-    subjectAccessRequestId = subjectAccessRequestId,
-  )
-
-  /**
-   * An error is "retryable" if it's a 5xx error or a client request error. 4xx client response errors are not retried.
-   */
-  private fun isRetryableError(error: Throwable): Boolean =
-    error is WebClientResponseException && error.statusCode.is5xxServerError || error is WebClientRequestException
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/models/SubjectAccessRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/models/SubjectAccessRequest.kt
@@ -24,4 +24,10 @@ data class SubjectAccessRequest(
   val claimAttempts: Int = 0,
   val objectUrl: String? = null,
   val lastDownloaded: LocalDateTime? = null,
+  /**
+   * ContextId is unique ID specifically for logging, providing a mechanism to identify all events from 1 thread of
+   * processing. If 2 workers are working on the same job it makes it possible to see which events belong together.
+   **/
+  @Transient
+  val contextId: UUID? = UUID.randomUUID(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
@@ -97,7 +97,7 @@ class SubjectAccessRequestWorkerService(
         message = "subject access request threw unexpected error",
         cause = exception,
         event = null,
-        subjectAccessRequestId = subjectAccessRequest?.id,
+        subjectAccessRequest = subjectAccessRequest,
         mapOf(
           "sarCaseReferenceNumber" to subjectAccessRequest?.sarCaseReferenceNumber,
         ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/utils/WebClientRetriesSpec.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/utils/WebClientRetriesSpec.kt
@@ -41,7 +41,7 @@ class WebClientRetriesSpec(
 
   fun retry5xxAndClientRequestErrors(
     event: ProcessingEvent,
-    subjectAccessRequest: SubjectAccessRequest?,
+    subjectAccessRequest: SubjectAccessRequest? = null,
     params: Map<String, Any>? = null,
   ): RetryBackoffSpec {
     return Retry
@@ -60,7 +60,7 @@ class WebClientRetriesSpec(
           retryAttempts = signal.totalRetries(),
           cause = signal.failure(),
           event = event,
-          subjectAccessRequestId = subjectAccessRequest?.id,
+          subjectAccessRequest = subjectAccessRequest,
           params = params,
         )
       }
@@ -74,13 +74,13 @@ class WebClientRetriesSpec(
 
   fun throw4xxStatusFatalError(
     event: ProcessingEvent,
-    subjectAccessRequest: SubjectAccessRequest?,
+    subjectAccessRequest: SubjectAccessRequest? = null,
     params: Map<String, Any>? = null,
   ) =
     { response: ClientResponse ->
       val moddedParams = buildMap<String, Any> {
         params?.let { putAll(it) }
-        putIfAbsent("uri", response.request().uri)
+        putIfAbsent("uri", response.request().uri.toString())
         putIfAbsent("httpStatus", response.statusCode())
       }
 
@@ -90,7 +90,7 @@ class WebClientRetriesSpec(
         FatalSubjectAccessRequestException(
           message = "client 4xx response status",
           event = event,
-          subjectAccessRequestId = subjectAccessRequest?.id,
+          subjectAccessRequest = subjectAccessRequest,
           params = moddedParams,
         ),
       )
@@ -104,9 +104,9 @@ class WebClientRetriesSpec(
 
     Mono.error<SubjectAccessRequestException>(
       SubjectAccessRequestDocumentStoreConflictException(
-        subjectAccessRequestId = subjectAccessRequest.id,
+        subjectAccessRequest = subjectAccessRequest,
         mapOf(
-          "uri" to response.request().uri,
+          "uri" to response.request().uri.toString(),
           "httpStatus" to response.statusCode(),
         ),
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/SubjectAccessRequestTestUtil.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/SubjectAccessRequestTestUtil.kt
@@ -26,7 +26,6 @@ fun <T : Throwable?> assertExpectedSubjectAccessRequestException(
   expectedSubjectAccessRequest: SubjectAccessRequest? = null,
   expectedParams: Map<String, *>? = null,
 ) {
-
   assertThat(actual.cause)
     .withFailMessage("actual.cause was null expected type: ${expectedCause.simpleName}")
     .isNotNull
@@ -44,7 +43,6 @@ fun assertExpectedSubjectAccessRequestExceptionWithCauseNull(
   expectedSubjectAccessRequest: SubjectAccessRequest? = null,
   expectedParams: Map<String, *>? = null,
 ) {
-
   assertThat(actual.cause).isNull()
 
   assertException(actual, expectedPrefix, expectedEvent, expectedSubjectAccessRequest, expectedParams)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/SubjectAccessRequestTestUtil.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/SubjectAccessRequestTestUtil.kt
@@ -1,6 +1,9 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.integration
 
 import org.assertj.core.api.Assertions.assertThat
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.SubjectAccessRequestException
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAccessRequest
 import java.math.BigInteger
 import java.security.MessageDigest
 
@@ -15,11 +18,63 @@ fun fileHash(bytes: ByteArray): String =
       .digest(bytes),
   ).toString(HEX_RADIX)
 
-fun assertExpectedErrorMessage(actual: Throwable, prefix: String, vararg params: Pair<String, *>) {
-  val formattedParams = params.joinToString(", ") { entry ->
-    "${entry.first}=${entry.second}"
-  }
+fun <T : Throwable?> assertExpectedSubjectAccessRequestException(
+  actual: SubjectAccessRequestException,
+  expectedPrefix: String,
+  expectedCause: Class<T>,
+  expectedEvent: ProcessingEvent? = null,
+  expectedSubjectAccessRequest: SubjectAccessRequest? = null,
+  expectedParams: Map<String, *>? = null,
+) {
 
-  assertThat(actual.message).startsWith(prefix)
-  assertThat(actual.message).endsWith(formattedParams)
+  assertThat(actual.cause)
+    .withFailMessage("actual.cause was null expected type: ${expectedCause.simpleName}")
+    .isNotNull
+  assertThat(actual.cause)
+    .withFailMessage("actual.cause did not match expected type: expected: ${expectedCause.simpleName}, actual: ${actual.cause!!::class.java.simpleName}")
+    .isInstanceOf(expectedCause)
+
+  assertException(actual, expectedPrefix, expectedEvent, expectedSubjectAccessRequest, expectedParams)
+}
+
+fun assertExpectedSubjectAccessRequestExceptionWithCauseNull(
+  actual: SubjectAccessRequestException,
+  expectedPrefix: String,
+  expectedEvent: ProcessingEvent? = null,
+  expectedSubjectAccessRequest: SubjectAccessRequest? = null,
+  expectedParams: Map<String, *>? = null,
+) {
+
+  assertThat(actual.cause).isNull()
+
+  assertException(actual, expectedPrefix, expectedEvent, expectedSubjectAccessRequest, expectedParams)
+}
+
+private fun assertException(
+  actual: SubjectAccessRequestException,
+  expectedPrefix: String,
+  expectedEvent: ProcessingEvent? = null,
+  expectedSubjectAccessRequest: SubjectAccessRequest? = null,
+  expectedParams: Map<String, *>? = null,
+) {
+  assertThat(actual.message)
+    .startsWith(expectedPrefix)
+
+  assertThat(actual.event)
+    .isEqualTo(expectedEvent)
+
+  assertThat(actual.subjectAccessRequest?.id)
+    .isEqualTo(expectedSubjectAccessRequest?.id)
+
+  assertThat(actual.subjectAccessRequest?.sarCaseReferenceNumber)
+    .isEqualTo(expectedSubjectAccessRequest?.sarCaseReferenceNumber)
+
+  assertThat(actual.subjectAccessRequest?.contextId)
+    .isEqualTo(expectedSubjectAccessRequest?.contextId)
+
+  when (expectedParams) {
+    null -> assertThat(actual.params).isNull()
+    else -> assertThat(actual.params)
+      .containsExactlyInAnyOrderEntriesOf(expectedParams)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/client/BaseClientIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/client/BaseClientIntTest.kt
@@ -2,6 +2,9 @@ package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.integration.clie
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
 import org.springframework.http.HttpStatus
+import org.springframework.security.oauth2.client.ClientAuthorizationException
+import org.springframework.web.reactive.function.client.WebClientRequestException
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.integration.IntegrationTestBase
 
 abstract class BaseClientIntTest : IntegrationTestBase() {
@@ -13,31 +16,31 @@ abstract class BaseClientIntTest : IntegrationTestBase() {
 
     @JvmStatic
     fun status4xxResponseStubs(): List<StubErrorResponse> = listOf(
-      StubErrorResponse(HttpStatus.BAD_REQUEST),
-      StubErrorResponse(HttpStatus.UNAUTHORIZED),
-      StubErrorResponse(HttpStatus.FORBIDDEN),
-      StubErrorResponse(HttpStatus.NOT_FOUND),
+      StubErrorResponse(HttpStatus.BAD_REQUEST, WebClientRequestException::class.java),
+      StubErrorResponse(HttpStatus.UNAUTHORIZED, WebClientRequestException::class.java),
+      StubErrorResponse(HttpStatus.FORBIDDEN, WebClientRequestException::class.java),
+      StubErrorResponse(HttpStatus.NOT_FOUND, WebClientRequestException::class.java),
     )
 
     @JvmStatic
     fun status5xxResponseStubs(): List<StubErrorResponse> = listOf(
-      StubErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR),
-      StubErrorResponse(HttpStatus.BAD_GATEWAY),
-      StubErrorResponse(HttpStatus.SERVICE_UNAVAILABLE),
-      StubErrorResponse(HttpStatus.GATEWAY_TIMEOUT),
+      StubErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, WebClientResponseException.InternalServerError::class.java),
+      StubErrorResponse(HttpStatus.BAD_GATEWAY, WebClientResponseException.BadGateway::class.java),
+      StubErrorResponse(HttpStatus.SERVICE_UNAVAILABLE, WebClientResponseException.ServiceUnavailable::class.java),
+      StubErrorResponse(HttpStatus.GATEWAY_TIMEOUT, WebClientResponseException.GatewayTimeout::class.java),
     )
 
     @JvmStatic
     fun authErrorResponseStubs(): List<StubErrorResponse> = listOf(
-      StubErrorResponse(HttpStatus.UNAUTHORIZED),
-      StubErrorResponse(HttpStatus.FORBIDDEN),
-      StubErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR),
-      StubErrorResponse(HttpStatus.BAD_GATEWAY),
-      StubErrorResponse(HttpStatus.SERVICE_UNAVAILABLE),
-      StubErrorResponse(HttpStatus.GATEWAY_TIMEOUT),
+      StubErrorResponse(HttpStatus.UNAUTHORIZED, ClientAuthorizationException::class.java),
+      StubErrorResponse(HttpStatus.FORBIDDEN, ClientAuthorizationException::class.java),
+      StubErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, ClientAuthorizationException::class.java),
+      StubErrorResponse(HttpStatus.BAD_GATEWAY, ClientAuthorizationException::class.java),
+      StubErrorResponse(HttpStatus.SERVICE_UNAVAILABLE, ClientAuthorizationException::class.java),
+      StubErrorResponse(HttpStatus.GATEWAY_TIMEOUT, ClientAuthorizationException::class.java),
     )
 
-    data class StubErrorResponse(val status: HttpStatus) {
+    data class StubErrorResponse(val status: HttpStatus, val expectedException: Class<out Throwable>) {
       fun getResponse(): ResponseDefinitionBuilder = ResponseDefinitionBuilder()
         .withStatus(status.value())
         .withStatusMessage(status.reasonPhrase)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/client/ProbationApiClientIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/client/ProbationApiClientIntTest.kt
@@ -13,7 +13,8 @@ import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.Processing
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent.GET_OFFENDER_NAME
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.FatalSubjectAccessRequestException
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.SubjectAccessRequestException
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.integration.assertExpectedErrorMessage
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.integration.assertExpectedSubjectAccessRequestException
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.integration.assertExpectedSubjectAccessRequestExceptionWithCauseNull
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.mockservers.HmppsAuthApiExtension.Companion.hmppsAuth
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.mockservers.PrisonApiExtension.Companion.prisonApi
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.mockservers.ProbationApiExtension.Companion.probationApi
@@ -31,6 +32,7 @@ class ProbationApiClientIntTest : BaseClientIntTest() {
   private val subjectAccessRequest = SubjectAccessRequest(
     id = UUID.randomUUID(),
     sarCaseReferenceNumber = UUID.randomUUID().toString(),
+    contextId = UUID.randomUUID(),
   )
 
   companion object {
@@ -71,14 +73,16 @@ class ProbationApiClientIntTest : BaseClientIntTest() {
       subjectId = SUBJECT_ID,
     )
 
-    assertExpectedErrorMessage(
+    assertExpectedSubjectAccessRequestExceptionWithCauseNull(
       actual = exception,
-      prefix = "subjectAccessRequest failed with non-retryable error: client 4xx response status",
-      "event" to GET_OFFENDER_NAME,
-      "id" to subjectAccessRequest.id,
-      "subjectId" to SUBJECT_ID,
-      "uri" to "/probation-case/$SUBJECT_ID",
-      "httpStatus" to stubResponse.status,
+      expectedPrefix = "subjectAccessRequest failed with non-retryable error: client 4xx response status",
+      expectedEvent = GET_OFFENDER_NAME,
+      expectedSubjectAccessRequest = subjectAccessRequest,
+      expectedParams = mapOf(
+        "subjectId" to SUBJECT_ID,
+        "uri" to "/probation-case/$SUBJECT_ID",
+        "httpStatus" to stubResponse.status,
+      ),
     )
   }
 
@@ -97,12 +101,15 @@ class ProbationApiClientIntTest : BaseClientIntTest() {
       subjectId = SUBJECT_ID,
     )
 
-    assertExpectedErrorMessage(
+    assertExpectedSubjectAccessRequestException(
       actual = exception,
-      prefix = "subjectAccessRequest failed and max retry attempts (2) exhausted,",
-      "event" to GET_OFFENDER_NAME,
-      "id" to subjectAccessRequest.id,
-      "subjectId" to SUBJECT_ID,
+      expectedPrefix = "subjectAccessRequest failed and max retry attempts (2) exhausted",
+      expectedCause = stubResponse.expectedException,
+      expectedEvent = GET_OFFENDER_NAME,
+      expectedSubjectAccessRequest = subjectAccessRequest,
+      expectedParams = mapOf(
+        "subjectId" to SUBJECT_ID,
+      ),
     )
   }
 
@@ -117,12 +124,15 @@ class ProbationApiClientIntTest : BaseClientIntTest() {
 
     prisonApi.verifyApiNeverCalled()
 
-    assertExpectedErrorMessage(
+    assertExpectedSubjectAccessRequestException(
       actual = exception,
-      prefix = "subjectAccessRequest failed with non-retryable error: probationApiClient error authorization exception",
-      "event" to ProcessingEvent.ACQUIRE_AUTH_TOKEN,
-      "id" to subjectAccessRequest.id,
-      "cause" to "$AUTH_ERROR_PREFIX ${stubResponse.status.value()} ${stubResponse.status.reasonPhrase}: [no body]",
+      expectedPrefix = "subjectAccessRequest failed with non-retryable error: probationApiClient error authorization exception",
+      expectedCause = stubResponse.expectedException,
+      expectedEvent = ProcessingEvent.ACQUIRE_AUTH_TOKEN,
+      expectedSubjectAccessRequest = subjectAccessRequest,
+      expectedParams = mapOf(
+        "cause" to "$AUTH_ERROR_PREFIX ${stubResponse.status.value()} ${stubResponse.status.reasonPhrase}: [no body]",
+      ),
     )
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -8,7 +8,7 @@ management.endpoint:
 web-client:
   configuration:
     max-retries: 2
-    back-off: PT1S
+    back-off: PT0.25S
 
 
 hmpps-auth:


### PR DESCRIPTION
- Added `contextId` to tie events to a single processing action. ID is added to all appInsights events and exceptions.
- Refactored `SubjectAccessRequestException` to expose params via method.
- Updated tests to be less brittle - compares field values to ensure the expected params are present. Previously used `exception.message`.