### PR TITLE
HAAR-3316: fixed 404 error handling on prison/probation api get offender name re…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/PrisonApiClient.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.client
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import io.micrometer.common.util.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 import org.springframework.security.oauth2.client.ClientAuthorizationException
@@ -19,6 +19,13 @@ class PrisonApiClient(
   private val prisonApiWebClient: WebClient,
   private val webClientRetriesSpec: WebClientRetriesSpec,
 ) {
+
+  companion object {
+    private val emptyResponse = GetOffenderDetailsResponse(
+      lastName = "",
+      firstName = "",
+    )
+  }
 
   fun getOffenderName(subjectAccessRequest: SubjectAccessRequest, subjectId: String): String {
     return try {
@@ -49,10 +56,7 @@ class PrisonApiClient(
         // Return valid empty response when not found
         .onErrorReturn(
           SubjectNotFoundException::class.java,
-          GetOffenderDetailsResponse(
-            lastName = "",
-            firstName = "",
-          ),
+          emptyResponse,
         )
         .block()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/PrisonApiClient.kt
@@ -1,15 +1,18 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.client
 
-import org.apache.tomcat.util.json.JSONParser
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.micrometer.common.util.StringUtils
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
 import org.springframework.security.oauth2.client.ClientAuthorizationException
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent.ACQUIRE_AUTH_TOKEN
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent.GET_OFFENDER_NAME
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.FatalSubjectAccessRequestException
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.WebClientRetriesSpec
-import java.util.Locale
 
 @Service
 class PrisonApiClient(
@@ -24,6 +27,10 @@ class PrisonApiClient(
         .uri("/api/offenders/$subjectId")
         .retrieve()
         .onStatus(
+          { code: HttpStatusCode -> code.isSameCodeAs(HttpStatus.NOT_FOUND) },
+          { _ -> Mono.error(SubjectNotFoundException(subjectId)) },
+        )
+        .onStatus(
           webClientRetriesSpec.is4xxStatus(),
           webClientRetriesSpec.throw4xxStatusFatalError(
             GET_OFFENDER_NAME,
@@ -31,7 +38,7 @@ class PrisonApiClient(
             mapOf("subjectId" to subjectId),
           ),
         )
-        .bodyToMono(String::class.java)
+        .bodyToMono(GetOffenderDetailsResponse::class.java)
         .retryWhen(
           webClientRetriesSpec.retry5xxAndClientRequestErrors(
             GET_OFFENDER_NAME,
@@ -39,13 +46,17 @@ class PrisonApiClient(
             mapOf("subjectId" to subjectId),
           ),
         )
+        // Return valid empty response when not found
+        .onErrorReturn(
+          SubjectNotFoundException::class.java,
+          GetOffenderDetailsResponse(
+            lastName = "",
+            firstName = "",
+          ),
+        )
         .block()
 
-      val details = JSONParser(response).parseObject()
-      "${details["lastName"].toString().uppercase()}, ${
-        details["firstName"].toString().lowercase()
-          .replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
-      }"
+      response?.formatName() ?: ""
     } catch (ex: ClientAuthorizationException) {
       throw FatalSubjectAccessRequestException(
         message = "prisonApiClient error authorization exception",
@@ -58,4 +69,20 @@ class PrisonApiClient(
       )
     }
   }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  data class GetOffenderDetailsResponse(val lastName: String? = "", val firstName: String? = "") {
+    /**
+     * Return the offender name formatted as "SURNAME, forename" if both values present. Otherwise, return empty string
+     */
+    fun formatName(): String {
+      if (StringUtils.isEmpty(lastName) || StringUtils.isEmpty(firstName)) {
+        return ""
+      }
+
+      return "${lastName!!.uppercase()}, ${firstName!!.lowercase().replaceFirstChar { it.titlecase() }}"
+    }
+  }
+
+  class SubjectNotFoundException(subjectId: String) : RuntimeException("/api/offenders/$subjectId not found")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/PrisonApiClient.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.client
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import org.apache.commons.lang3.StringUtils
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 import org.springframework.security.oauth2.client.ClientAuthorizationException
@@ -13,6 +12,7 @@ import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.Processing
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.FatalSubjectAccessRequestException
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.WebClientRetriesSpec
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.formatName
 
 @Service
 class PrisonApiClient(
@@ -60,7 +60,7 @@ class PrisonApiClient(
         )
         .block()
 
-      response?.formatName() ?: ""
+      formatName(response?.firstName, response?.lastName)
     } catch (ex: ClientAuthorizationException) {
       throw FatalSubjectAccessRequestException(
         message = "prisonApiClient error authorization exception",
@@ -75,18 +75,7 @@ class PrisonApiClient(
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
-  data class GetOffenderDetailsResponse(val lastName: String? = "", val firstName: String? = "") {
-    /**
-     * Return the offender name formatted as "SURNAME, forename" if both values present. Otherwise, return empty string
-     */
-    fun formatName(): String {
-      if (StringUtils.isEmpty(lastName) || StringUtils.isEmpty(firstName)) {
-        return ""
-      }
-
-      return "${lastName!!.uppercase()}, ${firstName!!.lowercase().replaceFirstChar { it.titlecase() }}"
-    }
-  }
+  data class GetOffenderDetailsResponse(val lastName: String? = "", val firstName: String? = "")
 
   class SubjectNotFoundException(subjectId: String) : RuntimeException("/api/offenders/$subjectId not found")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/ProbationApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/ProbationApiClient.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.client
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
-import io.micrometer.common.util.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.springframework.http.HttpStatus
 import org.springframework.security.oauth2.client.ClientAuthorizationException
 import org.springframework.stereotype.Service
@@ -19,6 +19,10 @@ class ProbationApiClient(
   private val probationApiWebClient: WebClient,
   private val webClientRetriesSpec: WebClientRetriesSpec,
 ) {
+
+  companion object {
+    private val emptyResponse = GetOffenderDetailsResponse(NameDetails(surname = "", forename = ""))
+  }
 
   fun getOffenderName(subjectAccessRequest: SubjectAccessRequest, subjectId: String): String {
     return try {
@@ -52,7 +56,7 @@ class ProbationApiClient(
         // Return valid empty response when not found
         .onErrorReturn(
           SubjectNotFoundException::class.java,
-          GetOffenderDetailsResponse(NameDetails(surname = "", forename = "")),
+          emptyResponse,
         )
         .block()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/ProbationApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/ProbationApiClient.kt
@@ -1,14 +1,18 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.client
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.micrometer.common.util.StringUtils
+import org.springframework.http.HttpStatus
 import org.springframework.security.oauth2.client.ClientAuthorizationException
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent.ACQUIRE_AUTH_TOKEN
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent.GET_OFFENDER_NAME
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.FatalSubjectAccessRequestException
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.WebClientRetriesSpec
-import java.util.Locale
 
 @Service
 class ProbationApiClient(
@@ -23,6 +27,10 @@ class ProbationApiClient(
         .uri("/probation-case/$subjectId")
         .retrieve()
         .onStatus(
+          { status -> status.isSameCodeAs(HttpStatus.NOT_FOUND) },
+          { _ -> Mono.error(SubjectNotFoundException(subjectId)) },
+        )
+        .onStatus(
           webClientRetriesSpec.is4xxStatus(),
           webClientRetriesSpec.throw4xxStatusFatalError(
             GET_OFFENDER_NAME,
@@ -33,7 +41,7 @@ class ProbationApiClient(
             ),
           ),
         )
-        .bodyToMono(Map::class.java)
+        .bodyToMono(GetOffenderDetailsResponse::class.java)
         .retryWhen(
           webClientRetriesSpec.retry5xxAndClientRequestErrors(
             GET_OFFENDER_NAME,
@@ -41,14 +49,14 @@ class ProbationApiClient(
             mapOf("subjectId" to subjectId),
           ),
         )
+        // Return valid empty response when not found
+        .onErrorReturn(
+          SubjectNotFoundException::class.java,
+          GetOffenderDetailsResponse(NameDetails(surname = "", forename = "")),
+        )
         .block()
 
-      val nameMap = response["name"] as Map<String, String>
-
-      "${nameMap["surname"]?.uppercase()}, ${
-        nameMap["forename"]?.lowercase()
-          ?.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
-      }"
+      response?.nameDetails?.formatName() ?: ""
     } catch (ex: ClientAuthorizationException) {
       throw FatalSubjectAccessRequestException(
         message = "probationApiClient error authorization exception",
@@ -61,4 +69,25 @@ class ProbationApiClient(
       )
     }
   }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  data class GetOffenderDetailsResponse(
+    @JsonProperty("name")
+    val nameDetails: NameDetails?,
+  )
+
+  data class NameDetails(val surname: String? = "", val forename: String? = "") {
+    /**
+     * Return the offender name formatted as "SURNAME, forename" if both values present. Otherwise, return empty string
+     */
+    fun formatName(): String {
+      if (StringUtils.isEmpty(surname) || StringUtils.isEmpty(forename)) {
+        return ""
+      }
+
+      return "${surname!!.uppercase()}, ${forename!!.lowercase().replaceFirstChar { it.titlecase() }}"
+    }
+  }
+
+  class SubjectNotFoundException(subjectId: String) : RuntimeException("/probation-case/$subjectId not found")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/ProbationApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/ProbationApiClient.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.client
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
-import org.apache.commons.lang3.StringUtils
 import org.springframework.http.HttpStatus
 import org.springframework.security.oauth2.client.ClientAuthorizationException
 import org.springframework.stereotype.Service
@@ -13,6 +12,7 @@ import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.Processing
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.FatalSubjectAccessRequestException
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.WebClientRetriesSpec
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.formatName
 
 @Service
 class ProbationApiClient(
@@ -60,7 +60,7 @@ class ProbationApiClient(
         )
         .block()
 
-      response?.nameDetails?.formatName() ?: ""
+      formatName(response?.nameDetails?.forename, response?.nameDetails?.surname)
     } catch (ex: ClientAuthorizationException) {
       throw FatalSubjectAccessRequestException(
         message = "probationApiClient error authorization exception",
@@ -80,18 +80,7 @@ class ProbationApiClient(
     val nameDetails: NameDetails?,
   )
 
-  data class NameDetails(val surname: String? = "", val forename: String? = "") {
-    /**
-     * Return the offender name formatted as "SURNAME, forename" if both values present. Otherwise, return empty string
-     */
-    fun formatName(): String {
-      if (StringUtils.isEmpty(surname) || StringUtils.isEmpty(forename)) {
-        return ""
-      }
-
-      return "${surname!!.uppercase()}, ${forename!!.lowercase().replaceFirstChar { it.titlecase() }}"
-    }
-  }
+  data class NameDetails(val surname: String? = "", val forename: String? = "")
 
   class SubjectNotFoundException(subjectId: String) : RuntimeException("/probation-case/$subjectId not found")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
 import com.microsoft.applicationinsights.TelemetryClient
+import io.micrometer.common.util.StringUtils
 import io.sentry.Sentry
 import kotlinx.coroutines.delay
 import org.apache.commons.lang3.time.StopWatch
@@ -9,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.client.DocumentStorageClient
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.client.PrisonApiClient
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.client.ProbationApiClient
@@ -158,10 +158,12 @@ class SubjectAccessRequestWorkerService(
       TIME_ELAPSED_KEY to stopWatch.time.toString(),
     )
 
-    var subjectName: String
-    try {
-      subjectName = getSubjectName(subjectAccessRequest, subjectAccessRequest.nomisId, subjectAccessRequest.ndeliusCaseReferenceId)
-    } catch (exception: WebClientResponseException.NotFound) {
+    var subjectName: String = getSubjectName(
+      subjectAccessRequest,
+      subjectAccessRequest.nomisId,
+      subjectAccessRequest.ndeliusCaseReferenceId,
+    )
+    if (StringUtils.isEmpty(subjectName)) {
       subjectName = "No subject name found"
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/SubjectAccessRequestWorkerService.kt
@@ -1,9 +1,9 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
 import com.microsoft.applicationinsights.TelemetryClient
-import io.micrometer.common.util.StringUtils
 import io.sentry.Sentry
 import kotlinx.coroutines.delay
+import org.apache.commons.lang3.StringUtils
 import org.apache.commons.lang3.time.StopWatch
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/utils/SubjectAccessRequestDataFormatter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/utils/SubjectAccessRequestDataFormatter.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils
+
+import org.apache.commons.lang3.StringUtils
+
+fun formatName(forename: String?, surname: String?): String {
+  if (StringUtils.isEmpty(surname?.trim()) || StringUtils.isEmpty(forename?.trim())) {
+    return ""
+  }
+
+  return "${surname!!.uppercase()}, ${forename!!.lowercase().replaceFirstChar { it.titlecase() }}"
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/mockservers/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/mockservers/PrisonApiMockServer.kt
@@ -8,10 +8,12 @@ import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import com.google.gson.Gson
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.client.PrisonApiClient
 
 class PrisonApiMockServer : WireMockServer(8079) {
 
@@ -42,6 +44,18 @@ class PrisonApiMockServer : WireMockServer(8079) {
               }
               """.trimIndent(),
             ),
+        ),
+    )
+  }
+
+  fun stubGetOffenderDetails(subjectId: String, responseBody: PrisonApiClient.GetOffenderDetailsResponse) {
+    stubFor(
+      get("/api/offenders/$subjectId")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200)
+            .withBody(Gson().toJson(responseBody)),
         ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/mockservers/ProbationApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/mockservers/ProbationApiMockServer.kt
@@ -6,10 +6,12 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import com.google.gson.Gson
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.client.ProbationApiClient
 
 class ProbationApiMockServer : WireMockServer(4002) {
 
@@ -41,6 +43,18 @@ class ProbationApiMockServer : WireMockServer(4002) {
               }
               """.trimIndent(),
             ),
+        ),
+    )
+  }
+
+  fun stubGetOffenderDetails(subjectId: String, apiResponse: ProbationApiClient.GetOffenderDetailsResponse) {
+    stubFor(
+      get("/probation-case/$subjectId")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200)
+            .withBody(Gson().toJson(apiResponse)),
         ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/utils/SubjectAccessRequestDataFormatterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/utils/SubjectAccessRequestDataFormatterTest.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+class SubjectAccessRequestDataFormatterTest {
+
+  companion object {
+
+    @JvmStatic
+    fun testCases(): List<TestCase> = listOf(
+      TestCase(null, null, ""),
+      TestCase("", null, ""),
+      TestCase(null, "", ""),
+      TestCase("", "", ""),
+      TestCase("revolver", "ocelot", "OCELOT, Revolver"),
+      TestCase("soLiD", "SnAkE", "SNAKE, Solid"),
+      TestCase("     ", "     ", ""),
+    )
+  }
+
+  data class TestCase(val forename: String?, val surname: String?, val expectedResult: String)
+
+  @ParameterizedTest
+  @MethodSource("testCases")
+  fun `format name should return the expected value`(testCase: TestCase) {
+    val result = formatName(testCase.forename, testCase.surname)
+    assertThat(result).isEqualTo(testCase.expectedResult)
+  }
+}


### PR DESCRIPTION
Fixed error introduce by client retries logic on prison/probation API requests to get the offender name.

404 status should be handled and return an empty String instead of throwing a Fatal exception. The SAR worker will apply a default if the name is not found.