### PR TITLE
HAAR-3061: Ensure values are always escaped in templates

### DIFF
--- a/src/main/resources/templates/template_court-case-service.mustache
+++ b/src/main/resources/templates/template_court-case-service.mustache
@@ -6,7 +6,7 @@
         <br>
         <table class="data-table">
             <tr><td>Comment</td></tr>
-            <tr><td>{{{ optionalValue comment }}}</td></tr>
+            <tr><td>{{ optionalValue comment }}</td></tr>
         </table>
         <table class="data-table">
             <tr>

--- a/src/main/resources/templates/template_create-and-vary-a-licence-api.mustache
+++ b/src/main/resources/templates/template_create-and-vary-a-licence-api.mustache
@@ -4,7 +4,7 @@
     <br>
     <table class="summary-list">
         <tr><td>Type</td><td>{{ optionalValue typeCode }}</td></tr>
-        <tr><td>Status</td><td>{{{ optionalValue statusCode }}}</td></tr>
+        <tr><td>Status</td><td>{{ optionalValue statusCode }}</td></tr>
         <tr><td>Appointment person</td><td>{{ optionalValue appointmentPerson }}</td></tr>
         <tr><td>Appointment time</td><td>{{ optionalValue appointmentTime }}</td></tr>
         <tr><td>Appointment time type</td><td>{{ optionalValue appointmentTimeType }}</td></tr>
@@ -108,7 +108,7 @@
     <table class="data-table">
         <tr><td></td></tr>
         {{#bespokeConditions}}
-            <tr><td>{{{ optionalValue . }}}</td></tr>
+            <tr><td>{{ optionalValue . }}</td></tr>
         {{/bespokeConditions}}
         {{^bespokeConditions}}
             <tr><td>No Data Held</td></tr>

--- a/src/main/resources/templates/template_hmpps-non-associations-api.mustache
+++ b/src/main/resources/templates/template_hmpps-non-associations-api.mustache
@@ -35,7 +35,7 @@
         </table>
         <table class="data-table">
             <tr><td>Comment</td></tr>
-            <tr><td>{{{ optionalValue comment }}}</td></tr>
+            <tr><td>{{ optionalValue comment }}</td></tr>
         </table>
         <br>
         <h4>Creation details</h4>

--- a/src/main/resources/templates/template_hmpps-uof-data-api.mustache
+++ b/src/main/resources/templates/template_hmpps-uof-data-api.mustache
@@ -261,7 +261,7 @@
     {{#statements}}
         <h4>Statement {{ optionalValue id }}</h4>
         <table class="data-table">
-            <tr><td>Statement</td></tr><tr><td>{{{ optionalValue statement }}}</td></tr>
+            <tr><td>Statement</td></tr><tr><td>{{ optionalValue statement }}</td></tr>
         </table>
         <table class="summary-list">
             <tr><td>Created date</td><td>{{ optionalValue (formatDate createdDate) }}</td></tr>

--- a/src/main/resources/templates/template_keyworker-api.mustache
+++ b/src/main/resources/templates/template_keyworker-api.mustache
@@ -5,10 +5,10 @@
         <tr><td>Allocated at</td><td>{{ optionalValue (formatDate allocatedAt) }}</td></tr>
         <tr><td>Keyworker last name</td><td>{{ optionalValue keyworker.lastName }}</td></tr>
         <tr><td>Prison name</td><td>{{ getPrisonName prisonCode }}</td></tr>
-        <tr><td>Allocation type</td><td>{{{ optionalValue allocationType }}}</td></tr>
-        <tr><td>Allocation reason</td><td>{{{ optionalValue allocationReason }}}</td></tr>
+        <tr><td>Allocation type</td><td>{{ optionalValue allocationType }}</td></tr>
+        <tr><td>Allocation reason</td><td>{{ optionalValue allocationReason }}</td></tr>
         <tr><td>Allocation is active</td><td>{{ convertBoolean activeAllocation }}</td></tr>
         <tr><td>Allocation expired at</td><td>{{ optionalValue (formatDate allocationExpiredAt) }}</td></tr>
-        <tr><td>Deallocation reason</td><td>{{{ optionalValue deallocationReason }}}</td></tr>
+        <tr><td>Deallocation reason</td><td>{{ optionalValue deallocationReason }}</td></tr>
     </table>
 {{/.}}

--- a/src/main/resources/templates/template_offender-case-notes.mustache
+++ b/src/main/resources/templates/template_offender-case-notes.mustache
@@ -9,7 +9,7 @@
     </table>
     <table class="data-table">
         <tr><td>Text</td></tr>
-        <tr><td>{{{ optionalValue text }}}</td></tr>
+        <tr><td>{{ optionalValue text }}</td></tr>
     </table>
 
     {{#amendments}}
@@ -20,7 +20,7 @@
         </table>
         <table class="data-table">
             <tr><td>Additional note text</td></tr>
-            <tr><td>{{{ optionalValue additionalNoteText }}}</td></tr>
+            <tr><td>{{ optionalValue additionalNoteText }}</td></tr>
         </table>
     {{/amendments}}
 {{/.}}

--- a/src/test/resources/pdf/testutil/stubs/offender-case-notes-stub.json
+++ b/src/test/resources/pdf/testutil/stubs/offender-case-notes-stub.json
@@ -5,7 +5,7 @@
       "creationDateTime": "2024-02-27T11:57:18.083934",
       "type": "Aardvark Ordering Test 2",
       "subType": "Report to Headmaster",
-      "text": "Test",
+      "text": "Test <test.user@justice.gov.uk> Text",
       "authorUsername": "TEST_USER",
       "amendments": []
     },


### PR DESCRIPTION
Using unescaped values caused instances of text between <> would cause them to be stripped from the generated pdf as iText would complain about them being unrecognised tags. I don't believe there is any need to have unescaped html values in the templates where they were defined so have replace so they will be html escaped, once pushed through iText they will be rendered correctly as in their original form.