### PR TITLE
refactor generate pdf tests to use temp dir and ensure resources are …

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/BaseGeneratePdfTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/BaseGeneratePdfTest.kt
@@ -1,0 +1,61 @@
+package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
+
+import com.itextpdf.kernel.pdf.PdfDocument
+import com.itextpdf.kernel.pdf.PdfReader
+import com.itextpdf.kernel.pdf.PdfWriter
+import com.itextpdf.layout.Document
+import com.microsoft.applicationinsights.TelemetryClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.io.CleanupMode
+import org.junit.jupiter.api.io.TempDir
+import org.mockito.kotlin.mock
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
+import java.io.File
+import java.io.FileOutputStream
+
+abstract class BaseGeneratePdfTest {
+  protected val prisonDetailsRepository: PrisonDetailsRepository = mock()
+  protected val userDetailsRepository: UserDetailsRepository = mock()
+  protected val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
+  protected val templateRenderService = TemplateRenderService(templateHelpers)
+  protected val telemetryClient: TelemetryClient = mock()
+  protected val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+
+  /**
+   * Change to ON_SUCCESS/NEVER if you need to retain the generated PDF files after the tests have run.
+   */
+  @TempDir(cleanup = CleanupMode.ALWAYS)
+  @JvmField
+  protected var tempFolder: File? = null
+
+  protected fun generateSubjectAccessRequestPdf(filename: String, serviceList: List<DpsService>) {
+    createPdfDocument(filename).use { pdfDocument ->
+      Document(pdfDocument).use { document ->
+        generatePdfService.addData(pdfDocument, document, serviceList)
+      }
+    }
+  }
+
+  protected fun createPdfDocument(filename: String): PdfDocument = PdfDocument(
+    PdfWriter(
+      FileOutputStream(
+        resolveTempFilePath(filename),
+      ),
+    ),
+  )
+
+  protected fun getGeneratedPdfDocument(filename: String): PdfDocument = PdfDocument(
+    PdfReader(
+      resolveTempFilePath(filename),
+    ),
+  )
+
+  protected fun resolveTempFilePath(filename: String): String {
+    assertThat(tempFolder).isNotNull()
+    assertThat(tempFolder).exists()
+    return tempFolder!!.toPath().resolve(filename).toString().also { println("resolved to: $it") }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfAdjudicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfAdjudicationServiceTest.kt
@@ -1,39 +1,26 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
-import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfAdjudicationServiceTest {
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfAdjudicationServiceTest : BaseGeneratePdfTest() {
 
   @Test
   fun `generatePdfService  renders for Adjudications service`() {
-    val serviceList =
-      listOf(DpsService(name = "hmpps-manage-adjudications-api", content = testAdjudicationsServiceData))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream("dummy-template-adjudications.pdf")))
-    val document = Document(pdfDocument)
-    generatePdfService.addData(pdfDocument, document, serviceList)
-    document.close()
-    val reader = PdfDocument(PdfReader("dummy-template-adjudications.pdf"))
-    val text = PdfTextExtractor.getTextFromPage(reader.getPage(2))
-    assertThat(text).contains("Manage Adjudications")
+    val serviceList = listOf(
+      DpsService(
+        name = "hmpps-manage-adjudications-api",
+        content = testAdjudicationsServiceData,
+      ),
+    )
+    generateSubjectAccessRequestPdf("dummy-template-adjudications.pdf", serviceList)
+
+    getGeneratedPdfDocument("dummy-template-adjudications.pdf").use { doc ->
+      val text = PdfTextExtractor.getTextFromPage(doc.getPage(2))
+      assertThat(text).contains("Manage Adjudications")
+    }
   }
 
   private val testAdjudicationsServiceData: ArrayList<Any> =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfComplexityOfNeedsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfComplexityOfNeedsServiceTest.kt
@@ -1,40 +1,21 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
-import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfComplexityOfNeedsServiceTest {
-
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfComplexityOfNeedsServiceTest : BaseGeneratePdfTest() {
 
   @Test
   fun `generatePdfService renders for Complexity of Need Service`() {
     val serviceList = listOf(DpsService(name = "hmpps-complexity-of-need", content = complexityOfNeedServiceData))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream("dummy-template-con.pdf")))
-    val document = Document(pdfDocument)
-    generatePdfService.addData(pdfDocument, document, serviceList)
-    document.close()
+    generateSubjectAccessRequestPdf("dummy-template-con.pdf", serviceList)
 
-    val reader = PdfDocument(PdfReader("dummy-template-con.pdf"))
-    val text = PdfTextExtractor.getTextFromPage(reader.getPage(2))
-    assertThat(text).contains("Complexity of need")
+    getGeneratedPdfDocument("dummy-template-con.pdf").use { doc ->
+      val text = PdfTextExtractor.getTextFromPage(doc.getPage(2))
+      assertThat(text).contains("Complexity of need")
+    }
   }
 
   private val complexityOfNeedServiceData = arrayListOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfCourtCaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfCourtCaseServiceTest.kt
@@ -1,39 +1,21 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
-import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfCourtCaseServiceTest {
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfCourtCaseServiceTest : BaseGeneratePdfTest() {
 
   @Test
   fun `generatePdfService renders for Court Case Service`() {
     val serviceList = listOf(DpsService(name = "court-case-service", content = courtCaseServiceData))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream("dummy-template-court-case.pdf")))
-    val document = Document(pdfDocument)
-    generatePdfService.addData(pdfDocument, document, serviceList)
-    document.close()
+    generateSubjectAccessRequestPdf("dummy-template-court-case.pdf", serviceList)
 
-    val reader = PdfDocument(PdfReader("dummy-template-court-case.pdf"))
-    val text = PdfTextExtractor.getTextFromPage(reader.getPage(2))
-    assertThat(text).contains("Prepare a Case for Sentence")
+    getGeneratedPdfDocument("dummy-template-court-case.pdf").use { doc ->
+      val text = PdfTextExtractor.getTextFromPage(doc.getPage(2))
+      assertThat(text).contains("Prepare a Case for Sentence")
+    }
   }
 
   private val courtCaseServiceData = mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfCreateAndVaryLicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfCreateAndVaryLicenceServiceTest.kt
@@ -1,39 +1,26 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
-import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfCreateAndVaryLicenceServiceTest {
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfCreateAndVaryLicenceServiceTest : BaseGeneratePdfTest() {
 
   @Test
   fun `generatePdfService renders for Create and Vary a License Service`() {
-    val serviceList =
-      listOf(DpsService(name = "create-and-vary-a-licence-api", content = testCreateAndVaryLicenceServiceData))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream("dummy-cvl-template.pdf")))
-    val document = Document(pdfDocument)
-    generatePdfService.addData(pdfDocument, document, serviceList)
-    document.close()
-    val reader = PdfDocument(PdfReader("dummy-cvl-template.pdf"))
-    val text = PdfTextExtractor.getTextFromPage(reader.getPage(2))
-    assertThat(text).contains("Create and vary a licence")
+    val serviceList = listOf(
+      DpsService(
+        name = "create-and-vary-a-licence-api",
+        content = testCreateAndVaryLicenceServiceData,
+      ),
+    )
+    generateSubjectAccessRequestPdf("dummy-cvl-template.pdf", serviceList)
+
+    getGeneratedPdfDocument("dummy-cvl-template.pdf").use { pdfDocument ->
+      val text = PdfTextExtractor.getTextFromPage(pdfDocument.getPage(2))
+      assertThat(text).contains("Create and vary a licence")
+    }
   }
 
   private val testCreateAndVaryLicenceServiceData = mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfEducationAndWorkPlanServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfEducationAndWorkPlanServiceTest.kt
@@ -1,41 +1,26 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
-import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfEducationAndWorkPlanServiceTest {
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfEducationAndWorkPlanServiceTest : BaseGeneratePdfTest() {
 
   @Test
   fun `generatePdfService renders for Education and Work Plan Service`() {
-    val serviceList =
-      listOf(DpsService(name = "hmpps-education-and-work-plan-api", content = educationAndWorkPlanServiceData))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream("dummy-template-hmpps-education-and-work-plan-api.pdf")))
-    val document = Document(pdfDocument)
-    generatePdfService.addData(pdfDocument, document, serviceList)
-    document.close()
+    val serviceList = listOf(
+      DpsService(
+        name = "hmpps-education-and-work-plan-api",
+        content = educationAndWorkPlanServiceData,
+      ),
+    )
+    generateSubjectAccessRequestPdf("dummy-template-hmpps-education-and-work-plan-api.pdf", serviceList)
 
-    val reader = PdfDocument(PdfReader("dummy-template-hmpps-education-and-work-plan-api.pdf"))
-    val text = PdfTextExtractor.getTextFromPage(reader.getPage(2))
-
-    assertThat(text).contains("Personal Learning Plan")
+    getGeneratedPdfDocument("dummy-template-hmpps-education-and-work-plan-api.pdf").use { pdf ->
+      val text = PdfTextExtractor.getTextFromPage(pdf.getPage(2))
+      assertThat(text).contains("Personal Learning Plan")
+    }
   }
 
   private val educationAndWorkPlanServiceData: Any = mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfEducationEmploymentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfEducationEmploymentServiceTest.kt
@@ -1,41 +1,26 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
-import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfEducationEmploymentServiceTest {
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfEducationEmploymentServiceTest : BaseGeneratePdfTest() {
 
   @Test
   fun `generatePdfService renders for Education and Employment Service`() {
-    val serviceList =
-      listOf(DpsService(name = "hmpps-education-employment-api", content = educationEmploymentServiceData))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream("dummy-template-hmpps-education-employment-api.pdf")))
-    val document = Document(pdfDocument)
-    generatePdfService.addData(pdfDocument, document, serviceList)
-    document.close()
+    val serviceList = listOf(
+      DpsService(
+        name = "hmpps-education-employment-api",
+        content = educationEmploymentServiceData,
+      ),
+    )
+    generateSubjectAccessRequestPdf("dummy-template-hmpps-education-employment-api.pdf", serviceList)
 
-    val reader = PdfDocument(PdfReader("dummy-template-hmpps-education-employment-api.pdf"))
-    val text = PdfTextExtractor.getTextFromPage(reader.getPage(2))
-
-    assertThat(text).contains("Work Readiness")
+    getGeneratedPdfDocument("dummy-template-hmpps-education-employment-api.pdf").use { pdf ->
+      val text = PdfTextExtractor.getTextFromPage(pdf.getPage(2))
+      assertThat(text).contains("Work Readiness")
+    }
   }
 
   private val educationEmploymentServiceData: Any = mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfHomDetentionCurfewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfHomDetentionCurfewServiceTest.kt
@@ -1,38 +1,21 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
-import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfHomDetentionCurfewServiceTest {
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfHomDetentionCurfewServiceTest : BaseGeneratePdfTest() {
 
   @Test
   fun `generatePdfService renders for Home Detention Curfew Service`() {
     val serviceList = listOf(DpsService(name = "hmpps-hdc-api", content = homeDetentionCurfewServiceData))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream("dummy-hdc-template.pdf")))
-    val document = Document(pdfDocument)
-    generatePdfService.addData(pdfDocument, document, serviceList)
-    document.close()
-    val reader = PdfDocument(PdfReader("dummy-hdc-template.pdf"))
-    val text = PdfTextExtractor.getTextFromPage(reader.getPage(2))
-    assertThat(text).contains("Home Detention Curfew")
+    generateSubjectAccessRequestPdf("dummy-hdc-template.pdf", serviceList)
+
+    getGeneratedPdfDocument("dummy-hdc-template.pdf").use { pdf ->
+      val text = PdfTextExtractor.getTextFromPage(pdf.getPage(2))
+      assertThat(text).contains("Home Detention Curfew")
+    }
   }
 
   private val homeDetentionCurfewServiceData: Map<Any, Any> = mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfIncentivesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfIncentivesServiceTest.kt
@@ -1,39 +1,21 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
-import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfIncentivesServiceTest {
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfIncentivesServiceTest : BaseGeneratePdfTest() {
 
   @Test
   fun `generatePdfService renders for Incentives Service`() {
     val serviceList = listOf(DpsService(name = "hmpps-incentives-api", content = incentivesServiceData))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream("dummy-incentives-template.pdf")))
-    val document = Document(pdfDocument)
-    generatePdfService.addData(pdfDocument, document, serviceList)
-    document.close()
-    val reader = PdfDocument(PdfReader("dummy-incentives-template.pdf"))
-    val text = PdfTextExtractor.getTextFromPage(reader.getPage(2))
+    generateSubjectAccessRequestPdf("dummy-incentives-template.pdf", serviceList)
 
-    assertThat(text).contains("Incentives")
+    getGeneratedPdfDocument("dummy-incentives-template.pdf").use { pdf ->
+      val text = PdfTextExtractor.getTextFromPage(pdf.getPage(2))
+      assertThat(text).contains("Incentives")
+    }
   }
 
   private val incentivesServiceData: ArrayList<Any> = arrayListOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfInterventionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfInterventionsServiceTest.kt
@@ -1,41 +1,21 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
-import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfInterventionsServiceTest {
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfInterventionsServiceTest : BaseGeneratePdfTest() {
 
   @Test
   fun `generatePdfService renders for Interventions Service`() {
     val serviceList = listOf(DpsService(name = "hmpps-interventions-service", content = interventionsServiceData))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream("dummy-interventions-service-template.pdf")))
-    val document = Document(pdfDocument)
+    generateSubjectAccessRequestPdf("dummy-interventions-service-template.pdf", serviceList)
 
-    generatePdfService.addData(pdfDocument, document, serviceList)
-
-    document.close()
-    val reader = PdfDocument(PdfReader("dummy-interventions-service-template.pdf"))
-    val text = PdfTextExtractor.getTextFromPage(reader.getPage(2))
-
-    assertThat(text).contains("Refer and monitor an intervention")
+    getGeneratedPdfDocument("dummy-interventions-service-template.pdf").use { pdf ->
+      val text = PdfTextExtractor.getTextFromPage(pdf.getPage(2))
+      assertThat(text).contains("Refer and monitor an intervention")
+    }
   }
 
   private val interventionsServiceData: Map<Any, Any> = mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfKeyworkerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfKeyworkerServiceTest.kt
@@ -1,52 +1,37 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
-import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.PrisonDetail
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfKeyworkerServiceTest {
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfKeyworkerServiceTest : BaseGeneratePdfTest() {
 
   @Test
   fun `generatePdfService renders for Keyworker Service`() {
-    whenever(prisonDetailsRepository.findByPrisonId("MDI")).thenReturn(PrisonDetail("MDI", "Moorland (HMP & YOI)"))
+    whenever(prisonDetailsRepository.findByPrisonId("MDI"))
+      .thenReturn(PrisonDetail("MDI", "Moorland (HMP & YOI)"))
+
     val serviceList = listOf(DpsService(name = "keyworker-api", content = testKeyworkerServiceData))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream("dummy-keyworker-template.pdf")))
-    val document = Document(pdfDocument)
-    generatePdfService.addData(pdfDocument, document, serviceList)
-    document.close()
-    val reader = PdfDocument(PdfReader("dummy-keyworker-template.pdf"))
-    val page = reader.getPage(2)
-    val text = PdfTextExtractor.getTextFromPage(page)
+    generateSubjectAccessRequestPdf("dummy-keyworker-template.pdf", serviceList)
 
-    assertThat(text).contains("Keyworker")
-    assertThat(text).contains("MARKE")
-    assertThat(text).contains("Prison name")
-    assertThat(text).contains("Moorland (HMP & YOI)")
+    getGeneratedPdfDocument("dummy-keyworker-template.pdf").use { pdf ->
+      val page = pdf.getPage(2)
+      val text = PdfTextExtractor.getTextFromPage(page)
 
-    verify(prisonDetailsRepository, times(1)).findByPrisonId("MDI")
-    verifyNoMoreInteractions(prisonDetailsRepository)
+      assertThat(text).contains("Keyworker")
+      assertThat(text).contains("MARKE")
+      assertThat(text).contains("Prison name")
+      assertThat(text).contains("Moorland (HMP & YOI)")
+
+      verify(prisonDetailsRepository, times(1)).findByPrisonId("MDI")
+      verifyNoMoreInteractions(prisonDetailsRepository)
+    }
   }
 
   private val testKeyworkerServiceData: ArrayList<Any> = arrayListOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfLaunchPadServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfLaunchPadServiceTest.kt
@@ -1,40 +1,21 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
-import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfLaunchPadServiceTest {
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfLaunchPadServiceTest : BaseGeneratePdfTest() {
 
   @Test
   fun `generatePdfService renders for Launchpad Auth Service`() {
     val serviceList = listOf(DpsService(name = "launchpad-auth", content = launchPadServiceData))
-    val writer = PdfWriter(FileOutputStream("dummy-template-launchpad-auth.pdf"))
-    val pdfDocument = PdfDocument(writer)
-    val document = Document(pdfDocument)
-    generatePdfService.addData(pdfDocument, document, serviceList)
-    document.close()
+    generateSubjectAccessRequestPdf("dummy-template-launchpad-auth.pdf", serviceList)
 
-    val reader = PdfDocument(PdfReader("dummy-template-launchpad-auth.pdf"))
-    val text = PdfTextExtractor.getTextFromPage(reader.getPage(2))
-    assertThat(text).contains("Launchpad")
+    getGeneratedPdfDocument("dummy-template-launchpad-auth.pdf").use { pdf ->
+      val text = PdfTextExtractor.getTextFromPage(pdf.getPage(2))
+      assertThat(text).contains("Launchpad")
+    }
   }
 
   private val launchPadServiceData = arrayListOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfNonAssociationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfNonAssociationsServiceTest.kt
@@ -1,39 +1,21 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
-import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfNonAssociationsServiceTest {
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfNonAssociationsServiceTest : BaseGeneratePdfTest() {
 
   @Test
   fun `generatePdfService renders for Non-associations Service`() {
     val serviceList = listOf(DpsService(name = "hmpps-non-associations-api", content = nonAssociationsServiceData))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream("dummy-template-non-associations.pdf")))
-    val document = Document(pdfDocument)
-    generatePdfService.addData(pdfDocument, document, serviceList)
-    document.close()
+    generateSubjectAccessRequestPdf("dummy-template-non-associations.pdf", serviceList)
 
-    val reader = PdfDocument(PdfReader("dummy-template-non-associations.pdf"))
-    val text = PdfTextExtractor.getTextFromPage(reader.getPage(2))
-    assertThat(text).contains("Non-associations")
+    getGeneratedPdfDocument("dummy-template-non-associations.pdf").use { pdf ->
+      val text = PdfTextExtractor.getTextFromPage(pdf.getPage(2))
+      assertThat(text).contains("Non-associations")
+    }
   }
 
   private val nonAssociationsServiceData = mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfPrepareSomeoneForReleaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfPrepareSomeoneForReleaseServiceTest.kt
@@ -1,42 +1,26 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
-import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfPrepareSomeoneForReleaseServiceTest {
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfPrepareSomeoneForReleaseServiceTest : BaseGeneratePdfTest() {
 
   @Test
   fun `generatePdfService renders for Prepare Someone for Release service`() {
-    val serviceList =
-      listOf(DpsService(name = "hmpps-resettlement-passport-api", content = prepareSomeoneForReleaseServiceData))
+    val serviceList = listOf(
+      DpsService(
+        name = "hmpps-resettlement-passport-api",
+        content = prepareSomeoneForReleaseServiceData,
+      ),
+    )
+    generateSubjectAccessRequestPdf("dummy-resettlement-template.pdf", serviceList)
 
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream("dummy-resettlement-template.pdf")))
-    val document = Document(pdfDocument)
-    generatePdfService.addData(pdfDocument, document, serviceList)
-    document.close()
-
-    val reader = PdfDocument(PdfReader("dummy-resettlement-template.pdf"))
-    val text = PdfTextExtractor.getTextFromPage(reader.getPage(2))
-
-    assertThat(text).contains("Prepare Someone for Release")
+    getGeneratedPdfDocument("dummy-resettlement-template.pdf").use { pdf ->
+      val text = PdfTextExtractor.getTextFromPage(pdf.getPage(2))
+      assertThat(text).contains("Prepare Someone for Release")
+    }
   }
 
   private val prepareSomeoneForReleaseServiceData: Map<Any, Any> = mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfServiceApprovedPremisesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfServiceApprovedPremisesTest.kt
@@ -1,37 +1,18 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
 import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfServiceApprovedPremisesTest {
-
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfServiceApprovedPremisesTest : BaseGeneratePdfTest() {
 
   private fun writeAndThenReadPdf(testInput: List<Map<String, Map<String, List<Any?>>>>?): PdfDocument {
     val testFileName = "dummy-template-approved-premises.pdf"
     val serviceList = listOf(DpsService(name = "hmpps-approved-premises-api", content = testInput))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream(testFileName)))
-    Document(pdfDocument).use {
-      generatePdfService.addData(pdfDocument, it, serviceList)
-    }
-    return PdfDocument(PdfReader(testFileName))
+    generateSubjectAccessRequestPdf(testFileName, serviceList)
+    return getGeneratedPdfDocument(testFileName)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfServiceBookASecureMoveTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfServiceBookASecureMoveTest.kt
@@ -1,37 +1,18 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
 import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfServiceBookASecureMoveTest {
-
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfServiceBookASecureMoveTest : BaseGeneratePdfTest() {
 
   private fun writeAndThenReadPdf(testInput: ArrayList<Map<String, Map<String, Any>>>?): PdfDocument {
     val testFileName = "dummy-template-book-a-secure-move.pdf"
     val serviceList = listOf(DpsService(name = "hmpps-book-secure-move-api", content = testInput))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream(testFileName)))
-    Document(pdfDocument).use {
-      generatePdfService.addData(pdfDocument, it, serviceList)
-    }
-    return PdfDocument(PdfReader(testFileName))
+    generateSubjectAccessRequestPdf(testFileName, serviceList)
+    return getGeneratedPdfDocument(testFileName)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfServiceConsiderRecallTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfServiceConsiderRecallTest.kt
@@ -1,45 +1,29 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
 import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.UserDetail
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfServiceConsiderRecallTest {
-
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfServiceConsiderRecallTest : BaseGeneratePdfTest() {
 
   private fun writeAndThenReadPdf(
     testInput: Map<String, Any?>?,
   ): PdfDocument {
-    whenever(userDetailsRepository.findByUsername("USERA_ADM")).thenReturn(UserDetail("USERA_ADM", "Reacher"))
+    whenever(userDetailsRepository.findByUsername("USERA_ADM"))
+      .thenReturn(UserDetail("USERA_ADM", "Reacher"))
+
     val testFileName = "dummy-template-recall.pdf"
     val serviceList = listOf(DpsService(name = "make-recall-decision-api", content = testInput))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream(testFileName)))
-    Document(pdfDocument).use {
-      generatePdfService.addData(pdfDocument, it, serviceList)
-    }
-    return PdfDocument(PdfReader(testFileName))
+    generateSubjectAccessRequestPdf(testFileName, serviceList)
+
+    return getGeneratedPdfDocument(testFileName)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfServiceManagePrisonOffenderManagerCasesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfServiceManagePrisonOffenderManagerCasesTest.kt
@@ -1,39 +1,21 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
 import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfServiceManagePrisonOffenderManagerCasesTest {
-
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfServiceManagePrisonOffenderManagerCasesTest : BaseGeneratePdfTest() {
 
   private fun writeAndThenReadPdf(
     testInput: Map<String, Any?>?,
   ): PdfDocument {
     val testFileName = "dummy-template-moic.pdf"
     val testResponseObject = listOf(DpsService(name = "offender-management-allocation-manager", content = testInput))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream(testFileName)))
-    Document(pdfDocument).use {
-      generatePdfService.addData(pdfDocument, it, testResponseObject)
-    }
-    return PdfDocument(PdfReader(testFileName))
+    generateSubjectAccessRequestPdf(testFileName, testResponseObject)
+
+    return getGeneratedPdfDocument(testFileName)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfServiceOffenderCaseNotesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfServiceOffenderCaseNotesTest.kt
@@ -1,39 +1,21 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
-import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfServiceOffenderCaseNotesTest {
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfServiceOffenderCaseNotesTest : BaseGeneratePdfTest() {
 
   @Test
   fun `generatePdfService renders for Offender Case Notes Service`() {
     val serviceList = listOf(DpsService(name = "offender-case-notes", content = offenderCaseNoteServiceData))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream("dummy-template.pdf")))
-    val document = Document(pdfDocument)
-    generatePdfService.addData(pdfDocument, document, serviceList)
-    document.close()
-    val reader = PdfDocument(PdfReader("dummy-template.pdf"))
-    val text = PdfTextExtractor.getTextFromPage(reader.getPage(2))
+    generateSubjectAccessRequestPdf("dummy-template.pdf", serviceList)
 
-    assertThat(text).contains("Case note")
+    getGeneratedPdfDocument("dummy-template.pdf").use { pdf ->
+      val text = PdfTextExtractor.getTextFromPage(pdf.getPage(2))
+      assertThat(text).contains("Case note")
+    }
   }
 
   private val offenderCaseNoteServiceData: ArrayList<Any> = arrayListOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfServiceRestrictedPatientsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/GeneratePdfServiceRestrictedPatientsTest.kt
@@ -1,41 +1,23 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
 import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.PrisonDetail
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class GeneratePdfServiceRestrictedPatientsTest {
-
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class GeneratePdfServiceRestrictedPatientsTest : BaseGeneratePdfTest() {
 
   private fun writeAndThenReadPdf(
     testInput: Map<String, String>?,
   ): PdfDocument {
     val testFileName = "dummy-template-restricted-patients.pdf"
     val serviceList = listOf(DpsService(name = "hmpps-restricted-patients-api", content = testInput))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream(testFileName)))
-    Document(pdfDocument).use {
-      generatePdfService.addData(pdfDocument, it, serviceList)
-    }
-    return PdfDocument(PdfReader(testFileName))
+    generateSubjectAccessRequestPdf(testFileName, serviceList)
+
+    return getGeneratedPdfDocument(testFileName)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/PdfTransformPrisonNameTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/PdfTransformPrisonNameTest.kt
@@ -1,32 +1,16 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services
 
-import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfReader
-import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
-import com.itextpdf.layout.Document
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.DpsService
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.PrisonDetail
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.PrisonDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.UserDetailsRepository
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.utils.TemplateHelpers
-import java.io.FileOutputStream
 
-class PdfTransformPrisonNameTest {
-  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
-  private val userDetailsRepository: UserDetailsRepository = mock()
-  private val templateHelpers = TemplateHelpers(prisonDetailsRepository, userDetailsRepository)
-  private val templateRenderService = TemplateRenderService(templateHelpers)
-  private val telemetryClient: TelemetryClient = mock()
-  private val generatePdfService = GeneratePdfService(templateRenderService, telemetryClient)
+class PdfTransformPrisonNameTest : BaseGeneratePdfTest() {
 
   @Test
   fun `generatePdfService renders for prison Name when caseload id supplied`() {
@@ -39,24 +23,21 @@ class PdfTransformPrisonNameTest {
     whenever(prisonDetailsRepository.findByPrisonId("MDI")).thenReturn(PrisonDetail("MDI", "Moorland (HMP & YOI)"))
 
     val serviceList = listOf(DpsService(name = "replace-prison-id-service", content = serviceData))
-    val pdfDocument = PdfDocument(PdfWriter(FileOutputStream("dummy-prison-id-template.pdf")))
-    val document = Document(pdfDocument)
+    generateSubjectAccessRequestPdf("dummy-prison-id-template.pdf", serviceList)
 
-    generatePdfService.addData(pdfDocument, document, serviceList)
+    getGeneratedPdfDocument("dummy-prison-id-template.pdf").use { pdf ->
+      val text = PdfTextExtractor.getTextFromPage(pdf.getPage(2))
 
-    document.close()
-    val reader = PdfDocument(PdfReader("dummy-prison-id-template.pdf"))
-    val text = PdfTextExtractor.getTextFromPage(reader.getPage(2))
+      assertThat(text).contains("Prisoner Generic")
+      assertThat(text).contains("optionalValue")
+      assertThat(text).contains("getPrisonName")
+      assertThat(text).contains("Haslar Immigration")
+      assertThat(text).contains("Removal Centre")
 
-    assertThat(text).contains("Prisoner Generic")
-    assertThat(text).contains("optionalValue")
-    assertThat(text).contains("getPrisonName")
-    assertThat(text).contains("Haslar Immigration")
-    assertThat(text).contains("Removal Centre")
-
-    verify(prisonDetailsRepository, times(1)).findByPrisonId("MDI")
-    verify(prisonDetailsRepository, times(1)).findByPrisonId("HRI")
-    verifyNoMoreInteractions(prisonDetailsRepository)
+      verify(prisonDetailsRepository, times(1)).findByPrisonId("MDI")
+      verify(prisonDetailsRepository, times(1)).findByPrisonId("HRI")
+      verifyNoMoreInteractions(prisonDetailsRepository)
+    }
   }
 
   private val serviceData: Map<Any, Any> = mapOf(
@@ -70,6 +51,5 @@ class PdfTransformPrisonNameTest {
       "prison_id_helper_value" to "optionalValue",
       "prison_name_helper_value" to "getPrisonName",
     ),
-
   )
 }


### PR DESCRIPTION
Refactored GeneratedPDF tests to ensure generated files are deleted after test run and ensure that PDF resources are closed properly.