### PR TITLE
HAAR-3873: improve error logging

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/scheduled/SubjectAccessRequestProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/scheduled/SubjectAccessRequestProcessor.kt
@@ -77,6 +77,7 @@ class SubjectAccessRequestProcessor(
 
   private fun handleError(stopWatch: StopWatch, subjectAccessRequest: SubjectAccessRequest?, ex: Exception) {
     log.error(buildErrorMessage(subjectAccessRequest, ex), ex)
+    ex.printStackTrace()
 
     reportErrorEvent(subjectAccessRequest, ex, stopWatch)
 
@@ -111,9 +112,19 @@ class SubjectAccessRequestProcessor(
   ) = telemetryClient.trackSarEvent(
     name = "ReportFailedWithError",
     subjectAccessRequest = subjectAccessRequest,
-    "error" to (exception.message ?: ""),
+    "error" to getErrorMessage(exception),
     TIME_ELAPSED_KEY to stopWatch.getTime(TimeUnit.MILLISECONDS).toString(),
   )
+
+  private fun getErrorMessage(ex: Exception): String {
+    val exceptionName: String = ex.javaClass.simpleName
+
+    return ex.message?.takeIf {
+      it.isNotBlank()
+    } ?: ex.cause?.let {
+      "${exceptionName}_${it::class.java.simpleName}"
+    } ?: exceptionName
+  }
 
   private fun createSubjectAccessRequestExceptionFor(
     subjectAccessRequest: SubjectAccessRequest?,


### PR DESCRIPTION
- Added default error message if empty or null
- Re-added error stack trace to logs to help identify issue. Currently no details are included in the log to identify the error