### PR TITLE
HAAR-3873: Fix null pointer when html-renderer returns empty body with status 204

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/HtmlRendererApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/client/HtmlRendererApiClient.kt
@@ -87,5 +87,5 @@ class HtmlRendererApiClient(
     )
   }
 
-  data class HtmlRenderResponse(val documentKey: String)
+  data class HtmlRenderResponse(val documentKey: String?)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/ReportServiceImpl.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/ReportServiceImpl.kt
@@ -58,9 +58,9 @@ class ReportServiceImpl(
       log.info("submitted html render request for ${service.name!!}")
       trackRenderServiceHtml(service, subjectAccessRequest)
 
-      val response = htmlRendererApiClient.submitRenderRequest(subjectAccessRequest, service)
-      log.info("html render request ${response!!.documentKey} completed successfully")
-      trackRenderServiceHtmlComplete(service, subjectAccessRequest, response.documentKey)
+      htmlRendererApiClient.submitRenderRequest(subjectAccessRequest, service)
+      log.info("${subjectAccessRequest.id} html render request completed successfully")
+      trackRenderServiceHtmlComplete(service, subjectAccessRequest)
     }
   }
 
@@ -106,12 +106,10 @@ class ReportServiceImpl(
   private fun trackRenderServiceHtmlComplete(
     service: DpsService,
     subjectAccessRequest: SubjectAccessRequest,
-    documentKey: String,
   ) = telemetryClient.trackSarEvent(
     "RenderHtmlForService",
     subjectAccessRequest,
     "serviceName" to (service.name ?: "NA"),
     "serviceUrl" to service.url.toString(),
-    "documentKey" to documentKey,
   )
 }


### PR DESCRIPTION
Fix null pointer ex. When the document exists in the cache the html render returns empty response with status 204. This was causing an error when constructing the response entity which expected a non null string.