### PR TITLE
fix defect in create backlog request endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/controller/BacklogRequestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/controller/BacklogRequestController.kt
@@ -48,12 +48,15 @@ class BacklogRequestController(
     }
   }
 
-  private fun validateRequest(createBacklogRequest: CreateBacklogRequest) {
-    if (createBacklogRequest.sarCaseReferenceId.isNullOrBlank()) {
+  private fun validateRequest(request: CreateBacklogRequest) {
+    if (request.sarCaseReferenceId.isNullOrBlank()) {
       throw ValidationException("non null/empty value is required for sarCaseReferenceId")
     }
-    if (createBacklogRequest.nomisId.isNullOrEmpty() && createBacklogRequest.ndeliusCaseReferenceId.isNullOrEmpty()) {
+    if (request.nomisId.isNullOrEmpty() && request.ndeliusCaseReferenceId.isNullOrEmpty()) {
       throw ValidationException("a non null/empty value is required for nomisId or ndeliusCaseReferenceId")
+    }
+    if (!request.nomisId.isNullOrEmpty() && !request.ndeliusCaseReferenceId.isNullOrEmpty()) {
+      throw ValidationException("multiple ID's provided provided please provide either a nomisId or ndeliusCaseReferenceId")
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/models/BacklogRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/models/BacklogRequest.kt
@@ -46,8 +46,8 @@ data class BacklogRequest(
 
   constructor(request: CreateBacklogRequest) : this(
     sarCaseReferenceNumber = request.sarCaseReferenceId ?: "",
-    nomisId = request.nomisId,
-    ndeliusCaseReferenceId = request.nomisId,
+    nomisId = if (request.nomisId.isNullOrEmpty()) null else request.nomisId,
+    ndeliusCaseReferenceId = if (request.ndeliusCaseReferenceId.isNullOrEmpty()) null else request.ndeliusCaseReferenceId,
     dateTo = request.dateFrom,
     dateFrom = request.dateTo,
   )

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -54,4 +54,4 @@ s3:
 
 backlog-request:
   api:
-    enabled: false
+    enabled: true


### PR DESCRIPTION
- Fix defect in create backlog request endpoint that was mistakenly mapping `ndeliusId` to `nomisId`  when creating the request domain object from the request body.

- Fix defect that allowed backlog request to be created when both `ndeliusId` and `nomisId` were null.