### PR TITLE
HAAR-3993: fix processor logic to complete after all summaries saved

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/scheduled/BacklogRequestProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/scheduled/BacklogRequestProcessor.kt
@@ -49,7 +49,7 @@ class BacklogRequestProcessor(
             channel.close()
           }
 
-          channel.consumeEach { summary ->  addServiceSummary(backlogRequest, summary)}
+          channel.consumeEach { summary -> addServiceSummary(backlogRequest, summary) }
           attemptCompleteRequest(backlogRequest)
         }
         return


### PR DESCRIPTION
Updated processor logic to change backlog request status to complete after all summaries saved instead of after each.