### PR TITLE
HAAR-3957: updated processor to use async and supervisorScope

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/BacklogRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/BacklogRequestService.kt
@@ -116,7 +116,7 @@ class BacklogRequestService(
   }
 
   @Transactional
-  fun getPendingServiceSummariesForId(
+  fun getServicesToQueryForRequest(
     id: UUID,
   ): List<ServiceConfiguration> = serviceSummaryRepository.getPendingServiceSummariesForRequestId(id)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/BacklogRequestProcessorIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/BacklogRequestProcessorIntTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.integration
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
+import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.BeforeEach
@@ -17,6 +18,7 @@ import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.mockservers.HtmlR
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.BacklogRequest
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.BacklogRequestStatus
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.BacklogRequestStatus.COMPLETE
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.BacklogRequestStatus.PENDING
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.ServiceConfiguration
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.BacklogRequestRepository
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.repository.ServiceSummaryRepository
@@ -192,6 +194,56 @@ class BacklogRequestProcessorIntTest : IntegrationTestBase() {
     htmlRendererApi.verifySubjectDataHeldSummaryCalled(1, createSubjectDataHeldRequest("service-3"))
   }
 
+  @Test
+  fun `processor will process successful requests even if 1 or more requests fails with error`() = runTest {
+    val start = LocalDateTime.now()
+    val backlogRequest = createBacklogRequest()
+    assertThat(backlogRequest).isNotNull
+
+    hmppsAuth.stubGrantToken()
+
+    // Request 1 & 2 are successful, request 3 fails with status 500
+    stubRendererSubjectDataHeldResponse(createSubjectDataHeldRequest("service-1"), false)
+    stubRendererSubjectDataHeldResponse(createSubjectDataHeldRequest("service-2"), false)
+    stubRendererSubjectDataHeldResponseError(createSubjectDataHeldRequest("service-3"), 500)
+
+    await()
+      .atMost(TIMEOUT_SEC, TimeUnit.SECONDS)
+      .until { renderMockIsCalledNTimes(n = 3) && requestHasAtLeastNCompleteSummaries(id = backlogRequest!!.id, n = 2) }
+
+    val result = assertBacklogRequestIsNotComplete(
+      backlogRequestId = backlogRequest!!.id,
+      expectedClaimDateTimeAfter = start,
+    )
+
+    assertThat(result.serviceSummary).hasSize(2)
+
+    assertServiceSummaryExistsWithExpectedValues(
+      backlogRequestId = result.id,
+      serviceName = "service-1",
+      expectedOrder = 1,
+      expectedDataHeld = false,
+      expectedStatus = COMPLETE,
+    )
+    assertServiceSummaryExistsWithExpectedValues(
+      backlogRequestId = result.id,
+      serviceName = "service-2",
+      expectedOrder = 2,
+      expectedDataHeld = false,
+      expectedStatus = COMPLETE,
+    )
+
+    assertServiceSummaryDoesNotExist(
+      backlogRequestId = result.id,
+      serviceName = "service-3",
+      status = COMPLETE,
+    )
+
+    htmlRendererApi.verifySubjectDataHeldSummaryCalled(1, createSubjectDataHeldRequest("service-1"))
+    htmlRendererApi.verifySubjectDataHeldSummaryCalled(1, createSubjectDataHeldRequest("service-2"))
+    htmlRendererApi.verifySubjectDataHeldSummaryCalled(1, createSubjectDataHeldRequest("service-3"))
+  }
+
   private fun createBacklogRequest(): BacklogRequestOverview? = webTestClient
     .post()
     .uri("/subject-access-request/backlog")
@@ -217,6 +269,12 @@ class BacklogRequestProcessorIntTest : IntegrationTestBase() {
     .getOrNull()
     ?.let { COMPLETE == it.status } ?: false
 
+  private fun requestHasAtLeastNCompleteSummaries(id: UUID, n: Int) = backlogRequestRepository
+    .findByIdOrNull(id)?.let { req -> req.serviceSummary.count { summary -> summary.status == COMPLETE } >= n }
+    ?: false
+
+  private fun renderMockIsCalledNTimes(n: Int) = htmlRendererApi.allServeEvents.count() == n
+
   private fun DynamicServicesClient.SubjectDataHeldResponse.toJson(): String = objectMapper.writeValueAsString(this)
 
   private fun stubRendererSubjectDataHeldResponse(
@@ -240,27 +298,17 @@ class BacklogRequestProcessorIntTest : IntegrationTestBase() {
     )
   }
 
-  private fun stubRendererSubjectDataHeldFailsOnFirstAttempt(
+  private fun stubRendererSubjectDataHeldResponseError(
     expectedSubjectDataHeldRequest: DynamicServicesClient.SubjectDataHeldRequest,
-    dataHeld: Boolean,
+    status: Int,
   ) {
-    htmlRendererApi.stubSubjectDataHeldResponseRetryAfterFailure(
+    htmlRendererApi.stubSubjectDataHeldResponse(
       subjectDataHeldRequest = expectedSubjectDataHeldRequest,
-      responseOne = ResponseDefinitionBuilder
+      responseDefinition = ResponseDefinitionBuilder
         .responseDefinition()
         .withHeader("Content-Type", "application/json")
-        .withStatus(500),
-      responseTwo = ResponseDefinitionBuilder
-        .responseDefinition()
-        .withHeader("Content-Type", "application/json")
-        .withBody(
-          DynamicServicesClient.SubjectDataHeldResponse(
-            nomisId = testNomisId,
-            ndeliusId = testNdeliusId,
-            dataHeld = dataHeld,
-            serviceName = expectedSubjectDataHeldRequest.serviceName,
-          ).toJson(),
-        ).withStatus(200),
+        .withStatus(status)
+        .withUniformRandomDelay(10, 2000),
     )
   }
 
@@ -281,6 +329,34 @@ class BacklogRequestProcessorIntTest : IntegrationTestBase() {
       assertThat(backlogRequest.claimDateTime).isBetween(it, LocalDateTime.now())
     }
     return backlogRequest
+  }
+
+  private fun assertBacklogRequestIsNotComplete(
+    backlogRequestId: UUID,
+    expectedClaimDateTimeAfter: LocalDateTime?,
+  ): BacklogRequest {
+    val backlogRequest = backlogRequestRepository.findByIdOrNull(backlogRequestId)
+    assertThat(backlogRequest).isNotNull
+    assertThat(backlogRequest!!.status).isEqualTo(PENDING)
+    assertThat(backlogRequest.completedAt).isNull()
+    assertThat(backlogRequest.dataHeld).isNull()
+    expectedClaimDateTimeAfter?.let {
+      assertThat(backlogRequest.claimDateTime).isBetween(it, LocalDateTime.now())
+    }
+    return backlogRequest
+  }
+
+  private fun assertServiceSummaryDoesNotExist(
+    backlogRequestId: UUID,
+    serviceName: String,
+    status: BacklogRequestStatus,
+  ) {
+    val serviceSummary = serviceSummaryRepository.findOneByBacklogRequestIdAndServiceNameAndStatus(
+      backlogRequestId = backlogRequestId,
+      serviceName = serviceName,
+      status = status,
+    )
+    assertThat(serviceSummary).isNull()
   }
 
   private fun assertServiceSummaryExistsWithExpectedValues(


### PR DESCRIPTION
Updated backlog process to use `async` instead of `launch` and to use `supervisorScope` - this scope means coroutines are treated individually and any failed requests will not impact the other requests/couroutines.