### PR TITLE
Fix build issue.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/BaseProcessorIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/BaseProcessorIntTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.integration
 import com.itextpdf.kernel.pdf.PdfDocument
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
 import com.itextpdf.kernel.pdf.canvas.parser.listener.SimpleTextExtractionStrategy
+import org.apache.commons.lang3.StringUtils
 import org.assertj.core.api.Assertions.assertThat
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.integration.IntegrationTestFixture.Companion.testNomisId
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.LocationDetail
@@ -32,9 +33,12 @@ class BaseProcessorIntTest : IntegrationTestBase() {
       val actualPageN = PdfTextExtractor.getTextFromPage(actual.getPage(i), SimpleTextExtractionStrategy())
       val expectedPageN = PdfTextExtractor.getTextFromPage(expected.getPage(i), SimpleTextExtractionStrategy())
 
+      fun detailedErrorMessage(pageIndex: Int, actual: String, expected: String) = "actual page: $pageIndex did not " +
+        "match expected:\nActual:\n$actual\nExpected:\n$expected$\nDifference:\n${StringUtils.difference(actual, expected)}"
+
       assertThat(actualPageN)
+        .withFailMessage(detailedErrorMessage(i, actualPageN, expectedPageN))
         .isEqualToIgnoringCase(expectedPageN)
-        .withFailMessage("actual page: $i did not match expected.")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/BaseProcessorIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/integration/BaseProcessorIntTest.kt
@@ -29,9 +29,10 @@ class BaseProcessorIntTest : IntegrationTestBase() {
   protected fun assertUploadedDocumentMatchesExpectedPdf(actual: PdfDocument, expected: PdfDocument) {
     assertThat(actual.numberOfPages).isEqualTo(expected.numberOfPages)
 
+    val replaceWhitespaceRegex = Regex("\\s+")
     for (i in 1..actual.numberOfPages) {
-      val actualPageN = PdfTextExtractor.getTextFromPage(actual.getPage(i), SimpleTextExtractionStrategy())
-      val expectedPageN = PdfTextExtractor.getTextFromPage(expected.getPage(i), SimpleTextExtractionStrategy())
+      val actualPageN = PdfTextExtractor.getTextFromPage(actual.getPage(i), SimpleTextExtractionStrategy()).replace(replaceWhitespaceRegex, " ")
+      val expectedPageN = PdfTextExtractor.getTextFromPage(expected.getPage(i), SimpleTextExtractionStrategy()).replace(replaceWhitespaceRegex, " ")
 
       fun detailedErrorMessage(pageIndex: Int, actual: String, expected: String) = "actual page: $pageIndex did not " +
         "match expected:\nActual:\n$actual\nExpected:\n$expected$\nDifference:\n${StringUtils.difference(actual, expected)}"


### PR DESCRIPTION
Page content in reference pdf vs generated pdf was out by 1 word causing test failures:

```
This is the expected text
```
vs
```
This is the expected
text
```

Was unable to determine how or why is this happening (only happens in pipeline) and nothing in the code has changed? Perhaps a pipeline version issue?. 

Original test compared the text of each page of a reference pdf to the text from equivalent page in the generated pdf. I've updated test to now build a string of entire pdf text, strip all whitespace, new lines, tabs etc then compare that to the reference pdf text after applying the same processing. Long winded but confirms the text (minus the formatting) in both is equal.