### PR TITLE
HAAR-5717: Add openhtmltopdf renderer for service html conversion to pdf

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,8 @@ dependencies {
   implementation("org.apache.commons:commons-csv:1.14.1")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.22.1")
   implementation("com.github.ben-manes.caffeine:caffeine:3.2.4")
+  implementation("com.openhtmltopdf:openhtmltopdf-pdfbox:1.0.10")
+  implementation("org.jsoup:jsoup:1.17.2")
 
   testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.0.0")
   testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/SubjectAccessRequestWorker.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/SubjectAccessRequestWorker.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.annotation.EnableScheduling
@@ -8,6 +9,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @SpringBootApplication
 @EnableScheduling
 @EnableAsync
+@ConfigurationPropertiesScan
 class SubjectAccessRequestWorker
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/config/ApplicationProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/config/ApplicationProperties.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "application")
+data class ApplicationProperties(
+  val serviceRenderer: ServiceRenderer,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/config/RenderConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/config/RenderConfig.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.v2.ITextServicePdfRenderer
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.v2.OpenHtmlServicePdfRenderer
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.v2.ServicePdfRenderer
+
+@Configuration
+class RenderConfig {
+
+  @Bean
+  fun servicePdfRenderer(applicationProperties: ApplicationProperties): ServicePdfRenderer = when (applicationProperties.serviceRenderer) {
+    ServiceRenderer.ITEXT -> ITextServicePdfRenderer()
+    ServiceRenderer.OPENHTMLTOPDF -> OpenHtmlServicePdfRenderer()
+  }
+}
+
+enum class ServiceRenderer {
+  ITEXT,
+  OPENHTMLTOPDF,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/ITextServicePdfRenderer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/ITextServicePdfRenderer.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.v2
+
+import com.itextpdf.html2pdf.ConverterProperties
+import com.itextpdf.html2pdf.HtmlConverter
+import com.itextpdf.html2pdf.attach.impl.layout.HtmlPageBreak
+import com.itextpdf.layout.element.AreaBreak
+import com.itextpdf.layout.element.IBlockElement
+import com.itextpdf.layout.element.Image
+import com.itextpdf.layout.properties.AreaBreakType
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.SubjectAccessRequestException
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.createWritablePdfDocument
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.newDocument
+import java.io.InputStream
+import java.nio.file.Path
+
+class ITextServicePdfRenderer : ServicePdfRenderer {
+
+  companion object {
+    private val converterProperties: ConverterProperties = ConverterProperties()
+  }
+
+  override suspend fun generateServicePdf(servicePdfPath: Path, serviceHtml: InputStream) {
+    createWritablePdfDocument(output = servicePdfPath).use { pdf ->
+      newDocument(pdf).use {
+        HtmlConverter.convertToElements(serviceHtml, converterProperties).forEach { element ->
+          when (element) {
+            is IBlockElement -> it.add(element)
+            is Image -> it.add(element)
+            is HtmlPageBreak -> it.add(AreaBreak(AreaBreakType.NEXT_PAGE))
+            else -> {
+              throw SubjectAccessRequestException("Unsupported element type found ${element.javaClass}")
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/OpenHtmlServicePdfRenderer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/OpenHtmlServicePdfRenderer.kt
@@ -1,0 +1,87 @@
+package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.v2
+
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jsoup.Jsoup
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.nio.file.Path
+
+class OpenHtmlServicePdfRenderer : ServicePdfRenderer {
+
+  override suspend fun generateServicePdf(servicePdfPath: Path, serviceHtml: InputStream) {
+    withContext(Dispatchers.IO) {
+      val rawHtml = serviceHtml.bufferedReader(Charsets.UTF_8).use { it.readText() }
+      val xhtml = buildXhtmlDocument(serviceHtml = rawHtml)
+
+      FileOutputStream(servicePdfPath.toFile()).use { outputStream ->
+        PdfRendererBuilder()
+          .useFastMode()
+          .withHtmlContent(xhtml, servicePdfPath.parent.toUri().toString())
+          .toStream(outputStream)
+          .run()
+      }
+    }
+  }
+
+  private fun buildXhtmlDocument(serviceHtml: String): String {
+    val serviceFragment = Jsoup.parseBodyFragment(serviceHtml)
+
+    serviceFragment.outputSettings()
+      .syntax(org.jsoup.nodes.Document.OutputSettings.Syntax.xml)
+      .escapeMode(org.jsoup.nodes.Entities.EscapeMode.xhtml)
+      .charset(Charsets.UTF_8)
+      .prettyPrint(false)
+
+    val serviceCss = serviceFragment
+      .select("style")
+      .joinToString("\n") { it.html() }
+
+    serviceFragment.select("style").remove()
+
+    val serviceBodyHtml = serviceFragment.body().html()
+
+    return """
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="UTF-8" />
+          <style type="text/css">
+            @page {
+              size: A4;
+              margin: 70px 35px 70px 35px;
+            }
+
+            body {
+              margin: 0;
+              font-family: Arial, Helvetica, sans-serif;
+              font-size: 12pt;
+              color: #0b0c0c;
+            }
+
+            img {
+              max-width: 100%;
+            }
+
+            table {
+              border-collapse: collapse;
+            }
+
+            .page-break {
+              page-break-before: always;
+              break-before: page;
+            }
+
+            $serviceCss
+          </style>
+        </head>
+        <body>
+          <main>
+            $serviceBodyHtml
+          </main>
+        </body>
+      </html>
+    """.trimIndent()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/PdfService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/PdfService.kt
@@ -1,20 +1,13 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.v2
 
-import com.itextpdf.html2pdf.ConverterProperties
-import com.itextpdf.html2pdf.HtmlConverter
-import com.itextpdf.html2pdf.attach.impl.layout.HtmlPageBreak
 import com.itextpdf.io.font.constants.StandardFonts
 import com.itextpdf.kernel.font.PdfFontFactory
 import com.itextpdf.kernel.pdf.PdfDocument
 import com.itextpdf.kernel.pdf.event.PdfDocumentEvent
 import com.itextpdf.kernel.utils.PdfMerger
 import com.itextpdf.layout.Document
-import com.itextpdf.layout.element.AreaBreak
-import com.itextpdf.layout.element.IBlockElement
-import com.itextpdf.layout.element.Image
 import com.itextpdf.layout.element.Paragraph
 import com.itextpdf.layout.element.Text
-import com.itextpdf.layout.properties.AreaBreakType
 import com.itextpdf.layout.properties.TextAlignment
 import com.microsoft.applicationinsights.TelemetryClient
 import org.apache.commons.lang3.StringUtils
@@ -29,7 +22,6 @@ import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.Processing
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent.GENERATE_PDF_COVER_STARTED
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent.GENERATE_PDF_SERVICE_DATA_ADDED
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent.GENERATE_PDF_STARTED
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.SubjectAccessRequestException
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.CustomHeaderEventHandler
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.ServiceConfiguration
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAccessRequest
@@ -50,11 +42,11 @@ class PdfService(
   private val dateService: DateService,
   private val attachmentsPdfService: AttachmentsPdfService,
   private val telemetryClient: TelemetryClient,
+  private val servicePdfRenderer: ServicePdfRenderer,
 ) {
 
   companion object {
     private val log = LoggerFactory.getLogger(PdfService::class.java)
-    private val converterProperties: ConverterProperties = ConverterProperties()
   }
 
   suspend fun renderSubjectAccessRequestPdf(pdfRenderRequest: PdfRenderRequest): Path {
@@ -98,25 +90,9 @@ class PdfService(
       )
 
       val servicePdfPath = pdfRenderRequest.serviceDataPdfPath(serviceConfiguration)
-
-      createWritablePdfDocument(output = servicePdfPath).use { pdf ->
-        newDocument(pdf).use {
-          getServiceHtml(pdfRenderRequest, serviceConfiguration).use { htmlInputStream ->
-            log.info("converting service {} html to pdf", subjectAccessRequest.id)
-
-            HtmlConverter.convertToElements(htmlInputStream, converterProperties).forEach { element ->
-              when (element) {
-                is IBlockElement -> it.add(element)
-                is Image -> it.add(element)
-                is HtmlPageBreak -> it.add(AreaBreak(AreaBreakType.NEXT_PAGE))
-                else -> {
-                  throw SubjectAccessRequestException("Unsupported element type found ${element.javaClass}")
-                }
-              }
-            }
-          }
-        }
-      }
+      val serviceHtml = getServiceHtml(pdfRenderRequest, serviceConfiguration)
+      log.info("converting service {} html to pdf", subjectAccessRequest.id)
+      servicePdfRenderer.generateServicePdf(servicePdfPath, serviceHtml)
 
       val attachments = documentStoreService.listAttachments(
         subjectAccessRequest = pdfRenderRequest.subjectAccessRequest,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/ServicePdfRenderer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/ServicePdfRenderer.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.v2
+
+import java.io.InputStream
+import java.nio.file.Path
+
+interface ServicePdfRenderer {
+  suspend fun generateServicePdf(servicePdfPath: Path, serviceHtml: InputStream)
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -166,3 +166,6 @@ springdoc:
     version: 5.32.2
   api-docs:
     enabled: false
+
+application:
+  service-renderer: itext

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/ITextServicePdfRendererTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/ITextServicePdfRendererTest.kt
@@ -1,0 +1,69 @@
+package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.v2
+
+import com.itextpdf.kernel.pdf.PdfDocument
+import com.itextpdf.kernel.pdf.PdfName
+import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
+import com.itextpdf.kernel.pdf.canvas.parser.listener.SimpleTextExtractionStrategy
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.getInputStream
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.getReadablePdfDocument
+import java.nio.file.Path
+
+class ITextServicePdfRendererTest {
+
+  @TempDir
+  lateinit var tempDir: Path
+
+  private val renderer = ITextServicePdfRenderer()
+
+  @Test
+  fun `should render html content to a valid pdf`() = runTest {
+    val outputPath = tempDir.resolve("service.pdf")
+
+    renderer.generateServicePdf(outputPath, "<h1>Test Service Report</h1>".byteInputStream())
+
+    assertThat(outputPath).exists()
+    getReadablePdfDocument(getInputStream(outputPath)).use { pdf ->
+      assertThat(pdf.numberOfPages).isEqualTo(1)
+      assertThat(pageText(pdf, 1)).contains("Test Service Report")
+    }
+  }
+
+  @Test
+  fun `should start a new page when the html contains a page break`() = runTest {
+    val html = """
+      <h1>Page one</h1>
+      <div style="page-break-before: always;"></div>
+      <h1>Page two</h1>
+    """.trimIndent()
+    val outputPath = tempDir.resolve("service.pdf")
+
+    renderer.generateServicePdf(outputPath, html.byteInputStream())
+
+    getReadablePdfDocument(getInputStream(outputPath)).use { pdf ->
+      assertThat(pdf.numberOfPages).isEqualTo(2)
+      assertThat(pageText(pdf, 1)).contains("Page one")
+      assertThat(pageText(pdf, 2)).contains("Page two")
+    }
+  }
+
+  @Test
+  fun `should render an image element to the pdf`() = runTest {
+    val base64Png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    val html = """<img src="data:image/png;base64,$base64Png" style="display:block;" />"""
+    val outputPath = tempDir.resolve("service.pdf")
+
+    renderer.generateServicePdf(outputPath, html.byteInputStream())
+
+    getReadablePdfDocument(getInputStream(outputPath)).use { pdf ->
+      assertThat(pdf.numberOfPages).isEqualTo(1)
+      val imageResources = pdf.getPage(1).resources.getResourceNames(PdfName.XObject)
+      assertThat(imageResources).isNotEmpty()
+    }
+  }
+
+  private fun pageText(pdf: PdfDocument, pageNumber: Int) = PdfTextExtractor.getTextFromPage(pdf.getPage(pageNumber), SimpleTextExtractionStrategy())
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/OpenHtmlServicePdfRendererTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/OpenHtmlServicePdfRendererTest.kt
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.v2
+
+import com.itextpdf.kernel.pdf.PdfDocument
+import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
+import com.itextpdf.kernel.pdf.canvas.parser.listener.SimpleTextExtractionStrategy
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.getInputStream
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.getReadablePdfDocument
+import java.nio.file.Path
+
+class OpenHtmlServicePdfRendererTest {
+
+  @TempDir
+  lateinit var tempDir: Path
+
+  private val renderer = OpenHtmlServicePdfRenderer()
+
+  @Test
+  fun `should render html content to a valid pdf`() = runTest {
+    val outputPath = tempDir.resolve("service.pdf")
+
+    renderer.generateServicePdf(outputPath, "<h1>Test Service Report</h1>".byteInputStream())
+
+    assertThat(outputPath).exists()
+    getReadablePdfDocument(getInputStream(outputPath)).use { pdf ->
+      assertThat(pdf.numberOfPages).isEqualTo(1)
+      assertThat(pageText(pdf, 1)).contains("Test Service Report")
+    }
+  }
+
+  @Test
+  fun `should start a new page when the html contains a page break`() = runTest {
+    val html = """
+      <h1>Page one</h1>
+      <div class="page-break"></div>
+      <h1>Page two</h1>
+    """.trimIndent()
+    val outputPath = tempDir.resolve("service.pdf")
+
+    renderer.generateServicePdf(outputPath, html.byteInputStream())
+
+    getReadablePdfDocument(getInputStream(outputPath)).use { pdf ->
+      assertThat(pdf.numberOfPages).isEqualTo(2)
+      assertThat(pageText(pdf, 1)).contains("Page one")
+      assertThat(pageText(pdf, 2)).contains("Page two")
+    }
+  }
+
+  @Test
+  fun `should strip style tags from the html and apply them as css rather than rendering their raw content`() = runTest {
+    val html = """
+      <style>p { color: #ff0000; }</style>
+      <h1>Test Service Report</h1>
+    """.trimIndent()
+    val outputPath = tempDir.resolve("service.pdf")
+
+    renderer.generateServicePdf(outputPath, html.byteInputStream())
+
+    getReadablePdfDocument(getInputStream(outputPath)).use { pdf ->
+      assertThat(pdf.numberOfPages).isEqualTo(1)
+      val text = pageText(pdf, 1)
+      assertThat(text).contains("Test Service Report")
+      assertThat(text).doesNotContain("color")
+    }
+  }
+
+  private fun pageText(pdf: PdfDocument, pageNumber: Int) = PdfTextExtractor.getTextFromPage(pdf.getPage(pageNumber), SimpleTextExtractionStrategy())
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/PdfServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/PdfServiceTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.v2
 import com.itextpdf.kernel.pdf.PdfDocument
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
 import com.itextpdf.kernel.pdf.canvas.parser.listener.SimpleTextExtractionStrategy
+import com.itextpdf.layout.element.Paragraph
 import com.microsoft.applicationinsights.TelemetryClient
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -16,6 +17,8 @@ import org.mockito.Captor
 import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -35,6 +38,8 @@ import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAcc
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.DateService
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.DocumentStoreService
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.attachments.AttachmentsPdfService
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.createWritablePdfDocument
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.newDocument
 import java.io.FileInputStream
 import java.io.InputStream
 import java.nio.file.Path
@@ -90,6 +95,7 @@ class PdfServiceTest {
       dateService = dateService,
       attachmentsPdfService = attachmentsPdfService,
       telemetryClient = telemetryClient,
+      servicePdfRenderer = ITextServicePdfRenderer(),
     )
   }
 
@@ -161,6 +167,69 @@ class PdfServiceTest {
 
     verify(attachmentsPdfService, never())
       .processAttachments(any(), any(), any())
+  }
+
+  @Test
+  fun `should delegate service pdf generation to the configured ServicePdfRenderer`() = runTest {
+    val servicePdfRenderer: ServicePdfRenderer = Mockito.mock()
+
+    whenever(requestServiceDetail1.serviceConfiguration)
+      .thenReturn(service1Config)
+
+    whenever(service1Config.serviceName)
+      .thenReturn(serviceName)
+
+    whenever(service1Config.label)
+      .thenReturn(serviceLabel)
+
+    whenever(documentStoreService.getTemplateVersion(subjectAccessRequest, serviceName))
+      .thenReturn("v1")
+
+    val serviceHtml = getHtmlInputStream(
+      path = getResourcePath("/integration-tests/html-stubs/$serviceName-expected.html"),
+    )
+
+    whenever(
+      documentStoreService.getDocument(
+        subjectAccessRequest = subjectAccessRequest,
+        serviceName = serviceName,
+        outputPath = sarBaseDir.resolve("html/$serviceName.html"),
+      ),
+    ).thenReturn(serviceHtml)
+
+    whenever(documentStoreService.listAttachments(subjectAccessRequest, serviceName))
+      .thenReturn(emptyList())
+
+    whenever(dateService.reportGenerationDate())
+      .thenReturn("1 January 2025")
+
+    whenever(dateService.reportDateFormat(dateFrom, "Start of record"))
+      .thenReturn("1 January 2024")
+
+    whenever(dateService.reportDateFormat(dateTo))
+      .thenReturn("1 January 2025")
+
+    doAnswer { invocation ->
+      val servicePdfPath = invocation.getArgument<Path>(0)
+      createWritablePdfDocument(servicePdfPath).use { pdf ->
+        newDocument(pdf).use { doc -> doc.add(Paragraph("stub content")) }
+      }
+    }.whenever(servicePdfRenderer).generateServicePdf(any(), any())
+
+    val pdfServiceWithConfiguredRenderer = PdfService(
+      documentStoreService = documentStoreService,
+      dateService = dateService,
+      attachmentsPdfService = attachmentsPdfService,
+      telemetryClient = telemetryClient,
+      servicePdfRenderer = servicePdfRenderer,
+    )
+
+    val actualPdfPath = pdfServiceWithConfiguredRenderer.renderSubjectAccessRequestPdf(pdfRenderRequest)
+
+    assertThat(actualPdfPath).exists()
+
+    verify(servicePdfRenderer, times(1))
+      .generateServicePdf(eq(pdfRenderRequest.serviceDataPdfPath(service1Config)), eq(serviceHtml))
   }
 
   private fun assertPageMatchesExpected(actualPdfDoc: PdfDocument, expectedPdfDoc: PdfDocument, pageNumber: Int) {


### PR DESCRIPTION
Adds a new option for rendering of service HTML to PDF via the OpenHtmlToPdf library, although not enabled by default so unless switched on the existing iText implementation will be used