### PR TITLE
HAAR-5753: Fix memory inefficiency defect

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/events/CustomHeaderEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/events/CustomHeaderEventHandler.kt
@@ -1,10 +1,8 @@
-package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models
+package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.events
 
 import com.itextpdf.io.font.constants.StandardFonts
-import com.itextpdf.io.font.constants.StandardFonts.HELVETICA
-import com.itextpdf.io.font.constants.StandardFonts.HELVETICA_BOLD
 import com.itextpdf.kernel.font.PdfFont
-import com.itextpdf.kernel.font.PdfFontFactory.createFont
+import com.itextpdf.kernel.font.PdfFontFactory
 import com.itextpdf.kernel.pdf.PdfDocument
 import com.itextpdf.kernel.pdf.event.AbstractPdfDocumentEvent
 import com.itextpdf.kernel.pdf.event.AbstractPdfDocumentEventHandler
@@ -15,7 +13,13 @@ import com.itextpdf.layout.element.Paragraph
 import com.itextpdf.layout.element.Text
 import com.itextpdf.layout.properties.TextAlignment
 
-class CustomHeaderEventHandler(private val pdfDoc: PdfDocument, val document: Document, private val subjectName: String, private val nomisId: String?, private val ndeliusCaseReferenceId: String?) : AbstractPdfDocumentEventHandler() {
+class CustomHeaderEventHandler(
+  private val pdfDoc: PdfDocument,
+  val document: Document,
+  private val subjectName: String,
+  private val nomisId: String?,
+  private val ndeliusCaseReferenceId: String?,
+) : AbstractPdfDocumentEventHandler() {
 
   override fun onAcceptedEvent(currentEvent: AbstractPdfDocumentEvent) {
     val docEvent = currentEvent as PdfDocumentEvent
@@ -36,13 +40,13 @@ class CustomHeaderEventHandler(private val pdfDoc: PdfDocument, val document: Do
       val subjectIdValue = nomisId ?: ndeliusCaseReferenceId ?: ""
       leftHeaderText = ""
       rightHeaderText = Paragraph()
-        .add(Text("Name: ").setFont(createFont(HELVETICA_BOLD)))
-        .add(Text(subjectName).setFont(createFont(HELVETICA)))
+        .add(Text("Name: ").setFont(PdfFontFactory.createFont(StandardFonts.HELVETICA_BOLD)))
+        .add(Text(subjectName).setFont(PdfFontFactory.createFont(StandardFonts.HELVETICA)))
         .add(Text("\n"))
-        .add(Text(subjectIdLabel).setFont(createFont(HELVETICA_BOLD)))
-        .add(Text(subjectIdValue).setFont(createFont(HELVETICA)))
+        .add(Text(subjectIdLabel).setFont(PdfFontFactory.createFont(StandardFonts.HELVETICA_BOLD)))
+        .add(Text(subjectIdValue).setFont(PdfFontFactory.createFont(StandardFonts.HELVETICA)))
     }
-    val font: PdfFont = createFont(StandardFonts.HELVETICA)
+    val font: PdfFont = PdfFontFactory.createFont(StandardFonts.HELVETICA)
     val pageSize = docEvent.page.pageSize
     val leftCoord = pageSize.left + document.leftMargin
     val rightCoord = pageSize.right - document.rightMargin

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/events/CustomHeaderEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/events/CustomHeaderEventHandler.kt
@@ -13,6 +13,7 @@ import com.itextpdf.layout.element.Paragraph
 import com.itextpdf.layout.element.Text
 import com.itextpdf.layout.properties.TextAlignment
 
+@Deprecated("deprecated and replaced by SubjectAccessRequestHeaderAndFooterEventHandler")
 class CustomHeaderEventHandler(
   private val pdfDoc: PdfDocument,
   val document: Document,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/events/SubjectAccessRequestHeaderAndFooterEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/events/SubjectAccessRequestHeaderAndFooterEventHandler.kt
@@ -60,7 +60,13 @@ open class SubjectAccessRequestHeaderAndFooterEventHandler(
   }
 }
 
-class SubjectAccessRequestOfficialSensitiveFooterEventHandler(document: Document) :
-  SubjectAccessRequestHeaderAndFooterEventHandler(document, "", null, null) {
+class SubjectAccessRequestOfficialSensitiveFooterEventHandler(
+  document: Document,
+) : SubjectAccessRequestHeaderAndFooterEventHandler(
+  document = document,
+  subjectName = "",
+  nomisId = null,
+  ndeliusCaseReferenceId = null,
+) {
   override fun getRightHeaderParagraph(): Paragraph = Paragraph()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/events/SubjectAccessRequestHeaderAndFooterEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/events/SubjectAccessRequestHeaderAndFooterEventHandler.kt
@@ -1,0 +1,66 @@
+package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.events
+
+import com.itextpdf.io.font.constants.StandardFonts
+import com.itextpdf.kernel.font.PdfFont
+import com.itextpdf.kernel.font.PdfFontFactory
+import com.itextpdf.kernel.pdf.event.AbstractPdfDocumentEvent
+import com.itextpdf.kernel.pdf.event.AbstractPdfDocumentEventHandler
+import com.itextpdf.kernel.pdf.event.PdfDocumentEvent
+import com.itextpdf.layout.Canvas
+import com.itextpdf.layout.Document
+import com.itextpdf.layout.element.Paragraph
+import com.itextpdf.layout.element.Text
+import com.itextpdf.layout.properties.TextAlignment
+
+open class SubjectAccessRequestHeaderAndFooterEventHandler(
+  val document: Document,
+  val subjectName: String,
+  val nomisId: String?,
+  val ndeliusCaseReferenceId: String?,
+) : AbstractPdfDocumentEventHandler() {
+
+  private companion object {
+    const val BOTTOM_PADDING: Int = 20
+    const val FONT_SIZE: Float = 10f
+    const val PAGE_FOOTER_TEXT: String = "Official Sensitive"
+  }
+
+  override fun onAcceptedEvent(event: AbstractPdfDocumentEvent?) {
+    val documentEvent = event as PdfDocumentEvent
+    val font: PdfFont = PdfFontFactory.createFont(StandardFonts.HELVETICA)
+    val pageSize = documentEvent.page.pageSize
+    val leftCoord = pageSize.left + document.leftMargin
+    val rightCoord = pageSize.right - document.rightMargin
+    val midCoord = (leftCoord + rightCoord) / 2
+    val headerY: Float = pageSize.top - document.topMargin
+    val footerY: Float = pageSize.bottom + BOTTOM_PADDING
+    val canvas = Canvas(documentEvent.page, pageSize)
+
+    canvas.use {
+      it.setFont(font)
+        .setFontSize(FONT_SIZE)
+        .showTextAligned(Paragraph(), leftCoord, headerY, TextAlignment.LEFT) // should this use empty string?
+        .simulateBold()
+        .showTextAligned(getRightHeaderParagraph(), rightCoord, headerY, TextAlignment.RIGHT)
+        .simulateBold()
+        .showTextAligned(PAGE_FOOTER_TEXT, midCoord, footerY, TextAlignment.CENTER)
+    }
+  }
+
+  open fun getRightHeaderParagraph(): Paragraph {
+    val subjectIdLabel = nomisId?.let { "NOMIS ID: " } ?: ndeliusCaseReferenceId?.let { "nDelius ID: " } ?: ""
+    val subjectIdValue = nomisId ?: ndeliusCaseReferenceId ?: ""
+
+    return Paragraph()
+      .add(Text("Name: ").setFont(PdfFontFactory.createFont(StandardFonts.HELVETICA_BOLD)))
+      .add(Text(subjectName).setFont(PdfFontFactory.createFont(StandardFonts.HELVETICA)))
+      .add(Text("\n"))
+      .add(Text(subjectIdLabel).setFont(PdfFontFactory.createFont(StandardFonts.HELVETICA_BOLD)))
+      .add(Text(subjectIdValue).setFont(PdfFontFactory.createFont(StandardFonts.HELVETICA)))
+  }
+}
+
+class SubjectAccessRequestOfficialSensitiveFooterEventHandler(document: Document) :
+  SubjectAccessRequestHeaderAndFooterEventHandler(document, "", null, null) {
+  override fun getRightHeaderParagraph(): Paragraph = Paragraph()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v1/PdfService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v1/PdfService.kt
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.config.trackSarEvent
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.SubjectAccessRequestException
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.CustomHeaderEventHandler
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.events.CustomHeaderEventHandler
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.ServiceConfiguration
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.DateService

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v1/PdfService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v1/PdfService.kt
@@ -24,13 +24,13 @@ import org.slf4j.LoggerFactory
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.config.trackSarEvent
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.SubjectAccessRequestException
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.events.CustomHeaderEventHandler
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.ServiceConfiguration
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.DateService
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.DocumentStoreService
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.ServiceConfigurationService
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.attachments.AttachmentsPdfService
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.events.CustomHeaderEventHandler
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.OutputStream

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/ITextServicePdfRenderer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/ITextServicePdfRenderer.kt
@@ -3,12 +3,14 @@ package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.v2
 import com.itextpdf.html2pdf.ConverterProperties
 import com.itextpdf.html2pdf.HtmlConverter
 import com.itextpdf.html2pdf.attach.impl.layout.HtmlPageBreak
+import com.itextpdf.kernel.pdf.event.PdfDocumentEvent
 import com.itextpdf.layout.element.AreaBreak
 import com.itextpdf.layout.element.IBlockElement
 import com.itextpdf.layout.element.Image
 import com.itextpdf.layout.properties.AreaBreakType
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.exception.SubjectAccessRequestException
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.createWritablePdfDocument
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.events.SubjectAccessRequestHeaderAndFooterEventHandler
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.newDocument
 import java.io.InputStream
 import java.nio.file.Path
@@ -19,14 +21,28 @@ class ITextServicePdfRenderer : ServicePdfRenderer {
     private val converterProperties: ConverterProperties = ConverterProperties()
   }
 
-  override suspend fun generateServicePdf(servicePdfPath: Path, serviceHtml: InputStream) {
+  override suspend fun generateServicePdf(
+    pdfRenderRequest: PdfRenderRequest,
+    servicePdfPath: Path,
+    serviceHtml: InputStream,
+  ) {
     createWritablePdfDocument(output = servicePdfPath).use { pdf ->
-      newDocument(pdf).use {
+      newDocument(pdf).use { document ->
+        pdf.addEventHandler(
+          PdfDocumentEvent.END_PAGE,
+          SubjectAccessRequestHeaderAndFooterEventHandler(
+            document = document,
+            subjectName = pdfRenderRequest.subjectName,
+            nomisId = pdfRenderRequest.subjectAccessRequest.nomisId,
+            ndeliusCaseReferenceId = pdfRenderRequest.subjectAccessRequest.ndeliusCaseReferenceId,
+          ),
+        )
+
         HtmlConverter.convertToElements(serviceHtml, converterProperties).forEach { element ->
           when (element) {
-            is IBlockElement -> it.add(element)
-            is Image -> it.add(element)
-            is HtmlPageBreak -> it.add(AreaBreak(AreaBreakType.NEXT_PAGE))
+            is IBlockElement -> document.add(element)
+            is Image -> document.add(element)
+            is HtmlPageBreak -> document.add(AreaBreak(AreaBreakType.NEXT_PAGE))
             else -> {
               throw SubjectAccessRequestException("Unsupported element type found ${element.javaClass}")
             }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/OpenHtmlServicePdfRenderer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/OpenHtmlServicePdfRenderer.kt
@@ -10,7 +10,11 @@ import java.nio.file.Path
 
 class OpenHtmlServicePdfRenderer : ServicePdfRenderer {
 
-  override suspend fun generateServicePdf(servicePdfPath: Path, serviceHtml: InputStream) {
+  override suspend fun generateServicePdf(
+    pdfRenderRequest: PdfRenderRequest,
+    servicePdfPath: Path,
+    serviceHtml: InputStream,
+  ) {
     withContext(Dispatchers.IO) {
       val rawHtml = serviceHtml.bufferedReader(Charsets.UTF_8).use { it.readText() }
       val xhtml = buildXhtmlDocument(serviceHtml = rawHtml)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/PdfService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/PdfService.kt
@@ -113,8 +113,8 @@ class PdfService(
       subjectAccessRequest = subjectAccessRequest,
       serviceName = serviceConfiguration.serviceName,
     ).takeIf { it.isNotEmpty() }?.let {
-
       val attachmentsPdfPath = pdfRenderRequest.serviceAttachmentsPdfPath(serviceConfiguration)
+
       createWritablePdfDocument(attachmentsPdfPath).use { pdf ->
         newDocument(pdf).use { attachmentsDocument ->
           log.info("appending service attachments to {} pdf", subjectAccessRequest.id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/PdfService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/PdfService.kt
@@ -2,10 +2,8 @@ package uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.v2
 
 import com.itextpdf.io.font.constants.StandardFonts
 import com.itextpdf.kernel.font.PdfFontFactory
-import com.itextpdf.kernel.pdf.PdfDocument
 import com.itextpdf.kernel.pdf.event.PdfDocumentEvent
 import com.itextpdf.kernel.utils.PdfMerger
-import com.itextpdf.layout.Document
 import com.itextpdf.layout.element.Paragraph
 import com.itextpdf.layout.element.Text
 import com.itextpdf.layout.properties.TextAlignment
@@ -22,13 +20,14 @@ import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.Processing
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent.GENERATE_PDF_COVER_STARTED
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent.GENERATE_PDF_SERVICE_DATA_ADDED
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.events.ProcessingEvent.GENERATE_PDF_STARTED
-import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.CustomHeaderEventHandler
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.ServiceConfiguration
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.DateService
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.DocumentStoreService
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.attachments.AttachmentsPdfService
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.createWritablePdfDocument
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.events.SubjectAccessRequestHeaderAndFooterEventHandler
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.events.SubjectAccessRequestOfficialSensitiveFooterEventHandler
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.getInputStream
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.getReadablePdfDocument
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.newDocument
@@ -92,27 +91,10 @@ class PdfService(
       val servicePdfPath = pdfRenderRequest.serviceDataPdfPath(serviceConfiguration)
       val serviceHtml = getServiceHtml(pdfRenderRequest, serviceConfiguration)
       log.info("converting service {} html to pdf using {}", subjectAccessRequest.id, servicePdfRenderer::class.simpleName)
-      servicePdfRenderer.generateServicePdf(servicePdfPath, serviceHtml)
+      servicePdfRenderer.generateServicePdf(pdfRenderRequest, servicePdfPath, serviceHtml)
 
-      val attachments = documentStoreService.listAttachments(
-        subjectAccessRequest = pdfRenderRequest.subjectAccessRequest,
-        serviceName = serviceConfiguration.serviceName,
-      )
-      if (!attachments.isEmpty()) {
-        val attachmentsPdfPath = pdfRenderRequest.serviceAttachmentsPdfPath(serviceConfiguration)
-        createWritablePdfDocument(attachmentsPdfPath).use { attachmentsPdf ->
+      generateServiceAttachments(pdfRenderRequest, serviceConfiguration)
 
-          newDocument(attachmentsPdf).use { attachmentsDocument ->
-            log.info("appending service attachments to {} pdf", subjectAccessRequest.id)
-
-            attachmentsPdfService.processAttachments(
-              subjectAccessRequest = pdfRenderRequest.subjectAccessRequest,
-              serviceName = serviceConfiguration.serviceName,
-              document = attachmentsDocument,
-            )
-          }
-        }
-      }
       telemetryClient.trackSarEvent(
         event = GENERATE_PDF_ADD_SERVICE_DATA_COMPLETED,
         subjectAccessRequest = pdfRenderRequest.subjectAccessRequest,
@@ -121,11 +103,52 @@ class PdfService(
     }
   }
 
+  private suspend fun generateServiceAttachments(
+    pdfRenderRequest: PdfRenderRequest,
+    serviceConfiguration: ServiceConfiguration,
+  ) {
+    val subjectAccessRequest = pdfRenderRequest.subjectAccessRequest
+
+    documentStoreService.listAttachments(
+      subjectAccessRequest = subjectAccessRequest,
+      serviceName = serviceConfiguration.serviceName,
+    ).takeIf { it.isNotEmpty() }?.let {
+
+      val attachmentsPdfPath = pdfRenderRequest.serviceAttachmentsPdfPath(serviceConfiguration)
+      createWritablePdfDocument(attachmentsPdfPath).use { pdf ->
+        newDocument(pdf).use { attachmentsDocument ->
+          log.info("appending service attachments to {} pdf", subjectAccessRequest.id)
+
+          pdf.addEventHandler(
+            PdfDocumentEvent.END_PAGE,
+            SubjectAccessRequestHeaderAndFooterEventHandler(
+              document = attachmentsDocument,
+              subjectName = pdfRenderRequest.subjectName,
+              nomisId = subjectAccessRequest.nomisId,
+              ndeliusCaseReferenceId = subjectAccessRequest.ndeliusCaseReferenceId,
+            ),
+          )
+
+          attachmentsPdfService.processAttachments(
+            subjectAccessRequest = pdfRenderRequest.subjectAccessRequest,
+            serviceName = serviceConfiguration.serviceName,
+            document = attachmentsDocument,
+          )
+        }
+      }
+    }
+  }
+
   private suspend fun generateInternalContentsPage(pdfRenderRequest: PdfRenderRequest) {
     telemetryClient.trackSarEvent(GENERATE_PDF_COVER_STARTED, pdfRenderRequest.subjectAccessRequest)
 
-    createWritablePdfDocument(pdfRenderRequest.internalContentsPagePdfPath).use { contentsPagePdf ->
-      newDocument(contentsPagePdf).use { doc ->
+    createWritablePdfDocument(pdfRenderRequest.internalContentsPagePdfPath).use { pdf ->
+      newDocument(pdf).use { document ->
+        pdf.addEventHandler(
+          PdfDocumentEvent.END_PAGE,
+          SubjectAccessRequestOfficialSensitiveFooterEventHandler(document),
+        )
+
         val contentsPageText = Paragraph()
           .setFont(PdfFontFactory.createFont(StandardFonts.HELVETICA))
           .setFontSize(16f)
@@ -133,7 +156,7 @@ class PdfService(
 
         contentsPageText.add(Text("\n\n\n"))
         contentsPageText.add(Text("CONTENTS\n"))
-        doc.add(contentsPageText)
+        document.add(contentsPageText)
 
         val services = pdfRenderRequest.subjectAccessRequest.getSelectedServices()
         val serviceListParagraph = Paragraph()
@@ -144,8 +167,8 @@ class PdfService(
               .setFontSize(14f)
           }
 
-        doc.add(serviceListParagraph)
-        doc.add(
+        document.add(serviceListParagraph)
+        document.add(
           Paragraph("\n\nINTERNAL ONLY")
             .setTextAlignment(TextAlignment.CENTER)
             .setFontSize(16f),
@@ -157,8 +180,13 @@ class PdfService(
   }
 
   private fun generateExternalCoverPage(pdfRenderRequest: PdfRenderRequest) {
-    createWritablePdfDocument(pdfRenderRequest.externalCoverPagePdfPath).use { pdfDoc ->
-      newDocument(pdfDoc).use { doc ->
+    createWritablePdfDocument(pdfRenderRequest.externalCoverPagePdfPath).use { pdf ->
+      newDocument(pdf).use { document ->
+        pdf.addEventHandler(
+          PdfDocumentEvent.END_PAGE,
+          SubjectAccessRequestOfficialSensitiveFooterEventHandler(document),
+        )
+
         val coverPageText = Paragraph()
           .setFont(PdfFontFactory.createFont(StandardFonts.HELVETICA))
           .setFontSize(16f)
@@ -166,15 +194,15 @@ class PdfService(
 
         coverPageText.add(Text("\u00a0\n").setFontSize(180f))
         coverPageText.add(Text("SUBJECT ACCESS REQUEST REPORT\n\n"))
-        doc.add(coverPageText)
-        doc.add(Paragraph("Name: ${pdfRenderRequest.subjectName}").setTextAlignment(TextAlignment.CENTER))
+        document.add(coverPageText)
+        document.add(Paragraph("Name: ${pdfRenderRequest.subjectName}").setTextAlignment(TextAlignment.CENTER))
 
         val subjectLine = getSubjectIdLine(
           pdfRenderRequest.subjectAccessRequest.nomisId,
           pdfRenderRequest.subjectAccessRequest.ndeliusCaseReferenceId,
         )
-        doc.add(Paragraph(subjectLine).setTextAlignment(TextAlignment.CENTER))
-        doc.add(
+        document.add(Paragraph(subjectLine).setTextAlignment(TextAlignment.CENTER))
+        document.add(
           Paragraph("SAR Case Reference Number: ${pdfRenderRequest.subjectAccessRequest.sarCaseReferenceNumber}")
             .setTextAlignment(TextAlignment.CENTER),
         )
@@ -217,8 +245,13 @@ class PdfService(
     val subjectAccessRequest = pdfRenderRequest.subjectAccessRequest
     val subjectName = pdfRenderRequest.subjectName
 
-    createWritablePdfDocument(pdfRenderRequest.internalCoverPagePdfPath).use { pdfDoc ->
-      newDocument(pdfDoc).use { doc ->
+    createWritablePdfDocument(pdfRenderRequest.internalCoverPagePdfPath).use { pdf ->
+      newDocument(pdf).use { document ->
+        pdf.addEventHandler(
+          PdfDocumentEvent.END_PAGE,
+          SubjectAccessRequestOfficialSensitiveFooterEventHandler(document),
+        )
+
         val coverPageText = Paragraph()
           .setFont(PdfFontFactory.createFont(StandardFonts.HELVETICA))
           .setFontSize(16f)
@@ -226,77 +259,75 @@ class PdfService(
 
         coverPageText.add(Text("\u00a0\n").setFontSize(180f))
         coverPageText.add(Text("SUBJECT ACCESS REQUEST REPORT\n\n"))
-        doc.add(coverPageText).setTextAlignment(TextAlignment.CENTER)
+        document.add(coverPageText).setTextAlignment(TextAlignment.CENTER)
 
-        doc.add(Paragraph("Name: $subjectName")).setTextAlignment(TextAlignment.CENTER)
+        document.add(Paragraph("Name: $subjectName")).setTextAlignment(TextAlignment.CENTER)
 
         val subjectLine = getSubjectIdLine(subjectAccessRequest.nomisId, subjectAccessRequest.ndeliusCaseReferenceId)
-        doc.add(Paragraph(subjectLine).setTextAlignment(TextAlignment.CENTER))
-        doc.add(
+        document.add(Paragraph(subjectLine).setTextAlignment(TextAlignment.CENTER))
+        document.add(
           Paragraph("SAR Case Reference Number: ${subjectAccessRequest.sarCaseReferenceNumber}").setTextAlignment(
             TextAlignment.CENTER,
           ),
         )
 
         val reportDateRange = getReportDateRangeLine(subjectAccessRequest.dateFrom, subjectAccessRequest.dateTo)
-        doc.add(Paragraph(reportDateRange).setTextAlignment(TextAlignment.CENTER))
-        doc.add(
+        document.add(Paragraph(reportDateRange).setTextAlignment(TextAlignment.CENTER))
+        document.add(
           Paragraph("Report generation date: ${dateService.reportGenerationDate()}").setTextAlignment(
             TextAlignment.CENTER,
           ),
         )
-        doc.add(
+        document.add(
           Paragraph("\nTotal Pages: ${reportBodyPageCount + 2}").setTextAlignment(TextAlignment.CENTER)
             .setFontSize(16f),
         )
-        doc.add(Paragraph("\nINTERNAL ONLY").setTextAlignment(TextAlignment.CENTER).setFontSize(16f))
-        doc.add(Paragraph("\nOFFICIAL-SENSITIVE").setTextAlignment(TextAlignment.CENTER).setFontSize(16f))
+        document.add(Paragraph("\nINTERNAL ONLY").setTextAlignment(TextAlignment.CENTER).setFontSize(16f))
+        document.add(Paragraph("\nOFFICIAL-SENSITIVE").setTextAlignment(TextAlignment.CENTER).setFontSize(16f))
       }
     }
   }
 
   private fun generateRearPage(pdfRenderRequest: PdfRenderRequest, reportBodyPageCount: Int) {
-    createWritablePdfDocument(output = pdfRenderRequest.rearPagePdfPath).use { pdfDoc ->
-      newDocument(pdfDoc).use { doc ->
+    createWritablePdfDocument(output = pdfRenderRequest.rearPagePdfPath).use { pdf ->
+      newDocument(pdf).use { document ->
+        pdf.addEventHandler(
+          PdfDocumentEvent.END_PAGE,
+          SubjectAccessRequestOfficialSensitiveFooterEventHandler(document),
+        )
+
         val endPageText = Paragraph()
           .setFont(PdfFontFactory.createFont(StandardFonts.HELVETICA))
           .setFontSize(16f)
           .setTextAlignment(TextAlignment.CENTER)
 
-        doc.add(Paragraph("\u00a0").setFontSize(300f))
+        document.add(Paragraph("\u00a0").setFontSize(300f))
 
         endPageText.add(Text("End of Subject Access Request Report\n\n"))
         endPageText.add(Text("Total pages: ${reportBodyPageCount + 2}\n\n")) // total = body + cover + rear page
         endPageText.add(Text("INTERNAL ONLY"))
-        doc.add(endPageText)
+        document.add(endPageText)
       }
     }
   }
 
   private fun mergePartialsIntoFullReportPdf(pdfRenderRequest: PdfRenderRequest) {
     createWritablePdfDocument(output = pdfRenderRequest.fullReportPdfPath).use { pdf ->
-      newDocument(pdf).use { doc ->
-        pdf.addEventHandler(
-          PdfDocumentEvent.END_PAGE,
-          getCustomerHeaderEventHandler(pdf, doc, pdfRenderRequest),
-        )
+      val merger = PdfMerger(pdf)
 
-        val merger = PdfMerger(pdf)
+      val internalCoverPagePath = pdfRenderRequest.internalCoverPagePdfPath
+      getReadablePdfDocument(getInputStream(internalCoverPagePath)).use { internalCoverPdf ->
+        merger.merge(internalCoverPdf, 1, internalCoverPdf.numberOfPages)
+      }
 
-        val internalCoverPagePath = pdfRenderRequest.internalCoverPagePdfPath
-        getReadablePdfDocument(getInputStream(internalCoverPagePath)).use { internalCoverPdf ->
-          merger.merge(internalCoverPdf, 1, internalCoverPdf.numberOfPages)
-        }
+      val reportBodyPath = pdfRenderRequest.reportBodyPdfPath
+      getReadablePdfDocument(getInputStream(reportBodyPath)).use { reportBodyPdf ->
+        merger.merge(reportBodyPdf, 1, reportBodyPdf.numberOfPages)
+      }
 
-        val reportBodyPath = pdfRenderRequest.reportBodyPdfPath
-        getReadablePdfDocument(getInputStream(reportBodyPath)).use { reportBodyPdf ->
-          merger.merge(reportBodyPdf, 1, reportBodyPdf.numberOfPages)
-        }
-
-        val rearPagePath = pdfRenderRequest.rearPagePdfPath
-        getReadablePdfDocument(getInputStream(rearPagePath)).use { rearPagePdf ->
-          merger.merge(rearPagePdf, 1, rearPagePdf.numberOfPages)
-        }
+      val rearPagePath = pdfRenderRequest.rearPagePdfPath
+      getReadablePdfDocument(getInputStream(rearPagePath)).use { rearPagePdf ->
+        merger.merge(rearPagePdf, 1, rearPagePdf.numberOfPages)
       }
     }
   }
@@ -308,18 +339,6 @@ class PdfService(
     subjectAccessRequest = pdfRenderRequest.subjectAccessRequest,
     serviceName = serviceConfiguration.serviceName,
     outputPath = pdfRenderRequest.serviceHtmlPath(serviceConfiguration),
-  )
-
-  private fun getCustomerHeaderEventHandler(
-    pdfDocument: PdfDocument,
-    document: Document,
-    pdfRenderRequest: PdfRenderRequest,
-  ) = CustomHeaderEventHandler(
-    pdfDoc = pdfDocument,
-    document = document,
-    subjectName = pdfRenderRequest.subjectName,
-    nomisId = pdfRenderRequest.subjectAccessRequest.nomisId,
-    ndeliusCaseReferenceId = pdfRenderRequest.subjectAccessRequest.ndeliusCaseReferenceId,
   )
 
   private suspend fun getServiceLabelWithTemplateVersion(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/ServicePdfRenderer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/ServicePdfRenderer.kt
@@ -4,5 +4,9 @@ import java.io.InputStream
 import java.nio.file.Path
 
 interface ServicePdfRenderer {
-  suspend fun generateServicePdf(servicePdfPath: Path, serviceHtml: InputStream)
+  suspend fun generateServicePdf(
+    pdfRenderRequest: PdfRenderRequest,
+    servicePdfPath: Path,
+    serviceHtml: InputStream,
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/ITextServicePdfRendererTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/ITextServicePdfRendererTest.kt
@@ -83,6 +83,6 @@ class ITextServicePdfRendererTest {
 
   private fun pageText(
     pdf: PdfDocument,
-    pageNumber: Int
+    pageNumber: Int,
   ) = PdfTextExtractor.getTextFromPage(pdf.getPage(pageNumber), SimpleTextExtractionStrategy())
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/ITextServicePdfRendererTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/ITextServicePdfRendererTest.kt
@@ -6,8 +6,11 @@ import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
 import com.itextpdf.kernel.pdf.canvas.parser.listener.SimpleTextExtractionStrategy
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.mockito.kotlin.mock
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.getInputStream
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.getReadablePdfDocument
 import java.nio.file.Path
@@ -17,13 +20,26 @@ class ITextServicePdfRendererTest {
   @TempDir
   lateinit var tempDir: Path
 
+  lateinit var pdfRenderRequest: PdfRenderRequest
+
+  private val subjectAccessRequest: SubjectAccessRequest = mock()
+
+  @BeforeEach
+  fun setup() {
+    pdfRenderRequest = PdfRenderRequest(
+      subjectName = "Barny Gumble",
+      subjectAccessRequest = subjectAccessRequest,
+      reportDir = tempDir,
+    )
+  }
+
   private val renderer = ITextServicePdfRenderer()
 
   @Test
   fun `should render html content to a valid pdf`() = runTest {
     val outputPath = tempDir.resolve("service.pdf")
 
-    renderer.generateServicePdf(outputPath, "<h1>Test Service Report</h1>".byteInputStream())
+    renderer.generateServicePdf(pdfRenderRequest, outputPath, "<h1>Test Service Report</h1>".byteInputStream())
 
     assertThat(outputPath).exists()
     getReadablePdfDocument(getInputStream(outputPath)).use { pdf ->
@@ -41,7 +57,7 @@ class ITextServicePdfRendererTest {
     """.trimIndent()
     val outputPath = tempDir.resolve("service.pdf")
 
-    renderer.generateServicePdf(outputPath, html.byteInputStream())
+    renderer.generateServicePdf(pdfRenderRequest, outputPath, html.byteInputStream())
 
     getReadablePdfDocument(getInputStream(outputPath)).use { pdf ->
       assertThat(pdf.numberOfPages).isEqualTo(2)
@@ -56,7 +72,7 @@ class ITextServicePdfRendererTest {
     val html = """<img src="data:image/png;base64,$base64Png" style="display:block;" />"""
     val outputPath = tempDir.resolve("service.pdf")
 
-    renderer.generateServicePdf(outputPath, html.byteInputStream())
+    renderer.generateServicePdf(pdfRenderRequest, outputPath, html.byteInputStream())
 
     getReadablePdfDocument(getInputStream(outputPath)).use { pdf ->
       assertThat(pdf.numberOfPages).isEqualTo(1)
@@ -65,5 +81,8 @@ class ITextServicePdfRendererTest {
     }
   }
 
-  private fun pageText(pdf: PdfDocument, pageNumber: Int) = PdfTextExtractor.getTextFromPage(pdf.getPage(pageNumber), SimpleTextExtractionStrategy())
+  private fun pageText(
+    pdf: PdfDocument,
+    pageNumber: Int
+  ) = PdfTextExtractor.getTextFromPage(pdf.getPage(pageNumber), SimpleTextExtractionStrategy())
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/OpenHtmlServicePdfRendererTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/OpenHtmlServicePdfRendererTest.kt
@@ -30,7 +30,7 @@ class OpenHtmlServicePdfRendererTest {
     pdfRenderRequest = PdfRenderRequest(
       subjectName = "Barny Gumble",
       subjectAccessRequest = subjectAccessRequest,
-      reportDir = tempDir
+      reportDir = tempDir,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/OpenHtmlServicePdfRendererTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/OpenHtmlServicePdfRendererTest.kt
@@ -5,8 +5,11 @@ import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
 import com.itextpdf.kernel.pdf.canvas.parser.listener.SimpleTextExtractionStrategy
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.mockito.kotlin.mock
+import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.models.SubjectAccessRequest
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.getInputStream
 import uk.gov.justice.digital.hmpps.subjectaccessrequestworker.services.pdf.getReadablePdfDocument
 import java.nio.file.Path
@@ -18,11 +21,24 @@ class OpenHtmlServicePdfRendererTest {
 
   private val renderer = OpenHtmlServicePdfRenderer()
 
+  private val subjectAccessRequest: SubjectAccessRequest = mock()
+
+  lateinit var pdfRenderRequest: PdfRenderRequest
+
+  @BeforeEach
+  fun setup() {
+    pdfRenderRequest = PdfRenderRequest(
+      subjectName = "Barny Gumble",
+      subjectAccessRequest = subjectAccessRequest,
+      reportDir = tempDir
+    )
+  }
+
   @Test
   fun `should render html content to a valid pdf`() = runTest {
     val outputPath = tempDir.resolve("service.pdf")
 
-    renderer.generateServicePdf(outputPath, "<h1>Test Service Report</h1>".byteInputStream())
+    renderer.generateServicePdf(pdfRenderRequest, outputPath, "<h1>Test Service Report</h1>".byteInputStream())
 
     assertThat(outputPath).exists()
     getReadablePdfDocument(getInputStream(outputPath)).use { pdf ->
@@ -40,7 +56,7 @@ class OpenHtmlServicePdfRendererTest {
     """.trimIndent()
     val outputPath = tempDir.resolve("service.pdf")
 
-    renderer.generateServicePdf(outputPath, html.byteInputStream())
+    renderer.generateServicePdf(pdfRenderRequest, outputPath, html.byteInputStream())
 
     getReadablePdfDocument(getInputStream(outputPath)).use { pdf ->
       assertThat(pdf.numberOfPages).isEqualTo(2)
@@ -57,7 +73,7 @@ class OpenHtmlServicePdfRendererTest {
     """.trimIndent()
     val outputPath = tempDir.resolve("service.pdf")
 
-    renderer.generateServicePdf(outputPath, html.byteInputStream())
+    renderer.generateServicePdf(pdfRenderRequest, outputPath, html.byteInputStream())
 
     getReadablePdfDocument(getInputStream(outputPath)).use { pdf ->
       assertThat(pdf.numberOfPages).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/PdfServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequestworker/services/pdf/v2/PdfServiceTest.kt
@@ -20,6 +20,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -171,7 +172,7 @@ class PdfServiceTest {
 
   @Test
   fun `should delegate service pdf generation to the configured ServicePdfRenderer`() = runTest {
-    val servicePdfRenderer: ServicePdfRenderer = Mockito.mock()
+    val servicePdfRenderer: ServicePdfRenderer = mock()
 
     whenever(requestServiceDetail1.serviceConfiguration)
       .thenReturn(service1Config)
@@ -210,11 +211,12 @@ class PdfServiceTest {
       .thenReturn("1 January 2025")
 
     doAnswer { invocation ->
-      val servicePdfPath = invocation.getArgument<Path>(0)
+      val servicePdfPath = invocation.getArgument<Path>(1)
       createWritablePdfDocument(servicePdfPath).use { pdf ->
         newDocument(pdf).use { doc -> doc.add(Paragraph("stub content")) }
       }
-    }.whenever(servicePdfRenderer).generateServicePdf(any(), any())
+    }.whenever(servicePdfRenderer)
+      .generateServicePdf(any(), any(), any())
 
     val pdfServiceWithConfiguredRenderer = PdfService(
       documentStoreService = documentStoreService,
@@ -227,9 +229,14 @@ class PdfServiceTest {
     val actualPdfPath = pdfServiceWithConfiguredRenderer.renderSubjectAccessRequestPdf(pdfRenderRequest)
 
     assertThat(actualPdfPath).exists()
+    val servicePdfPath = pdfRenderRequest.serviceDataPdfPath(service1Config)
 
     verify(servicePdfRenderer, times(1))
-      .generateServicePdf(eq(pdfRenderRequest.serviceDataPdfPath(service1Config)), eq(serviceHtml))
+      .generateServicePdf(
+        any(),
+        eq(servicePdfPath),
+        eq(serviceHtml),
+      )
   }
 
   private fun assertPageMatchesExpected(actualPdfDoc: PdfDocument, expectedPdfDoc: PdfDocument, pageNumber: Int) {


### PR DESCRIPTION
The `PdfService` creates several sub documents and then merges them together at the end to produce the final SAR PDF. The merge process also applies a custom header event which adds the SAR header/footer to each page. 

After analysing the memory usage it seems adding these header/footers during merge requires huge amounts of memory - presumably because it has to load the entire PDF doc into memory to apply the change to each page.

Testing with a 20MB HTML file the PDF service applying header/footer logic in the merge phase the app requires `~1700MB - 1900MB` for this step. Removing this custom event reduces this to `~350MB.`

Change updates the PDF generation tlogic o apply the header/footer during the partial page generation stage - the pages are already in memory at this point so it takes advantage of this opportunity. This should reduce the in peak memory requirement quite significantly as the whole document should not longer be loaded into memory.